### PR TITLE
Automatic restart based on deck key

### DIFF
--- a/epoch1d/src/constants.F90
+++ b/epoch1d/src/constants.F90
@@ -103,6 +103,7 @@ MODULE constants
   INTEGER, PARAMETER :: c_err_io_error = 2**15
   INTEGER, PARAMETER :: c_err_bad_setup = 2**16
   INTEGER, PARAMETER :: c_err_window = 2**17
+  INTEGER, PARAMETER :: c_err_ended_restart = 2**18
 
   INTEGER, PARAMETER :: c_ds_first = 1
   INTEGER, PARAMETER :: c_ds_last = 2

--- a/epoch1d/src/deck/deck_control_block.F90
+++ b/epoch1d/src/deck/deck_control_block.F90
@@ -180,9 +180,12 @@ CONTAINS
     CHARACTER(LEN=string_length) :: str_tmp
     CHARACTER(LEN=1) :: c
     INTEGER :: errcode
-    INTEGER :: field_order, ierr, io, iu, i
+    INTEGER :: field_order, ierr, io, iu, i, pre, lun, nl_loc
     LOGICAL :: isnum
     INTEGER, DIMENSION(:), POINTER :: stride_temp
+    INTEGER :: sz
+    LOGICAL :: exists
+    CHARACTER(LEN=:), ALLOCATABLE :: dname, str
 
     errcode = c_err_none
 
@@ -254,6 +257,74 @@ CONTAINS
         END DO
       END IF
       CALL abort_code(c_err_bad_value)
+
+    ELSE IF (str_cmp(element, 'use_restart_dependency_file')) THEN
+      use_restart_dependency_file = as_logical_print(value, element, errcode)
+      IF (errcode /= c_err_none .OR. .NOT. use_restart_dependency_file) RETURN
+      IF (rank == 0) THEN
+        INQUIRE(FILE=TRIM(data_dir) // '/' // TRIM(restart_dependency_file), &
+           exist = exists, size = sz)
+        IF (.NOT. exists .OR. sz <= 0) THEN
+          CALL MPI_BCAST(0, 1, MPI_INTEGER, 0, comm, ierr)
+          RETURN
+        END IF
+        lun=get_free_lun()
+        OPEN(UNIT=lun,FILE=TRIM(data_dir) // '/' &
+            // TRIM(restart_dependency_file), ACCESS='STREAM', STATUS='OLD')
+        ALLOCATE(CHARACTER(LEN=sz)::str)
+        READ(lun) str
+        CLOSE(lun)
+        nl_loc = sz
+        DO WHILE(nl_loc > 0)
+          pre = INDEX(str(:nl_loc-1), NEW_LINE('A'), BACK = .TRUE.)
+          IF (pre < 1) pre = 0
+          IF (pre == nl_loc) CYCLE
+          ALLOCATE(dname, SOURCE = str(pre+1:nl_loc-1))
+          IF (dname == restart_terminate_string) THEN
+            DO iu = 1, nio_units ! Print to stdout and to file
+              io = io_units(iu)
+              WRITE(io,*) '*** INFO ***'
+              WRITE(io,*) 'Code has reached true end point so will not restart'
+            END DO
+            CALL abort_code(c_err_ended_restart)
+          END IF
+          INQUIRE(FILE = TRIM(data_dir) // '/' // dname, exist = exists)
+          IF (exists) EXIT
+          DEALLOCATE(dname)
+          nl_loc = pre
+        END DO
+        IF (.NOT. ALLOCATED(dname)) THEN
+          DO iu = 1, nio_units ! Print to stdout and to file
+            io = io_units(iu)
+            WRITE(io,*) '*** ERROR ***'
+            WRITE(io,*) 'Restart dependency file does not specify any valid'
+            WRITE(io,*) 'files for restart. This is a fatal error and EPOCH'
+            WRITE(io,*) 'will close'
+          END DO
+          CALL MPI_BCAST(-1, 1, MPI_INTEGER, 0, comm, ierr)
+          errcode = c_err_bad_value + c_err_terminate
+          RETURN
+        END IF
+        CALL MPI_BCAST(LEN(dname), 1, MPI_INTEGER, 0, comm, ierr)
+        CALL MPI_BCAST(dname, LEN(dname), MPI_CHARACTER, 0, comm, &
+            ierr)
+        restart_filename = dname
+        DEALLOCATE(dname, str)
+        ic_from_restart = .TRUE.
+      ELSE
+        CALL MPI_BCAST(sz, 1, MPI_INTEGER, 0, comm, ierr)
+        IF (sz == 0) RETURN
+        IF (sz < 0) THEN
+          errcode = c_err_bad_value + c_err_terminate
+          RETURN
+        END IF
+        ALLOCATE(CHARACTER(LEN=sz)::dname)
+        CALL MPI_BCAST(dname, LEN(dname), MPI_CHARACTER, 0, comm, &
+            ierr)
+        restart_filename = dname
+        DEALLOCATE(dname)
+        ic_from_restart = .TRUE.
+      END IF
 
     ELSE IF (str_cmp(element, 'restart_snapshot')) THEN
       isnum = .TRUE.

--- a/epoch1d/src/io/diagnostics.F90
+++ b/epoch1d/src/io/diagnostics.F90
@@ -216,12 +216,12 @@ CONTAINS
     REAL(num), DIMENSION(:), ALLOCATABLE :: array
     INTEGER, DIMENSION(2,c_ndims) :: ranges
     INTEGER :: code, i, io, ispecies, iprefix, mask, rn, dir, dumped, nval, n
-    INTEGER :: errcode
+    INTEGER :: errcode, lun
     INTEGER :: random_state(4)
     INTEGER, ALLOCATABLE :: random_states_per_proc(:)
     INTEGER, DIMENSION(c_ndims) :: dims
     INTEGER, SAVE :: nstep_prev = -1
-    LOGICAL :: convert, force, any_written, restart_id, print_arrays
+    LOGICAL :: convert, force, any_written, restart_id, print_arrays, exists
     LOGICAL, SAVE :: first_call = .TRUE.
     TYPE(particle_species), POINTER :: species
     TYPE(subset), POINTER :: sub
@@ -898,6 +898,25 @@ CONTAINS
       CALL sdf_close(sdf_handle)
 
       IF (rank == 0) THEN
+        IF (restart_flag .AND. use_restart_dependency_file) THEN
+          lun = get_free_lun()
+          INQUIRE(FILE=TRIM(data_dir) // '/' //restart_dependency_file, &
+              exist = exists)
+          IF (.NOT. exists) THEN
+            OPEN(UNIT=lun, FILE=TRIM(data_dir) // '/' &
+                // restart_dependency_file, FORM="FORMATTED", STATUS="NEW")
+          ELSE
+            OPEN(UNIT=lun, FILE=TRIM(data_dir) // '/' &
+                // restart_dependency_file, FORM="FORMATTED", STATUS="OLD", &
+                POSITION="APPEND")
+          END IF
+          WRITE(lun,'(A)') TRIM(filename)
+          IF ((step >= nsteps .AND. nsteps >= 0) .OR. (time >= t_end)) THEN
+            WRITE(lun,'(A)') restart_terminate_string
+          END IF
+          CLOSE(lun)
+        END IF
+
         DO io = 1, n_io_blocks
           IF (io_block_list(io)%dump) THEN
             dump_type = TRIM(io_block_list(io)%name)

--- a/epoch1d/src/shared_data.F90
+++ b/epoch1d/src/shared_data.F90
@@ -281,6 +281,9 @@ MODULE shared_data
   INTEGER :: full_dump_every, restart_dump_every
   LOGICAL :: force_first_to_be_restartable
   LOGICAL :: force_final_to_be_restartable
+  LOGICAL :: use_restart_dependency_file = .FALSE.
+  CHARACTER(LEN=*), PARAMETER :: restart_dependency_file = 'restart.dep'
+  CHARACTER(LEN=*), PARAMETER :: restart_terminate_string = 'TERMINATE'
   LOGICAL :: use_offset_grid
   INTEGER :: n_zeros_control, n_zeros = 4
   INTEGER, DIMENSION(num_vars_to_dump) :: dumpmask

--- a/epoch2d/src/constants.F90
+++ b/epoch2d/src/constants.F90
@@ -103,6 +103,7 @@ MODULE constants
   INTEGER, PARAMETER :: c_err_io_error = 2**15
   INTEGER, PARAMETER :: c_err_bad_setup = 2**16
   INTEGER, PARAMETER :: c_err_window = 2**17
+  INTEGER, PARAMETER :: c_err_ended_restart = 2**18
 
   INTEGER, PARAMETER :: c_ds_first = 1
   INTEGER, PARAMETER :: c_ds_last = 2

--- a/epoch2d/src/deck/deck_control_block.F90
+++ b/epoch2d/src/deck/deck_control_block.F90
@@ -201,9 +201,12 @@ CONTAINS
     CHARACTER(LEN=string_length) :: str_tmp
     CHARACTER(LEN=1) :: c
     INTEGER :: errcode
-    INTEGER :: field_order, ierr, io, iu, i
+    INTEGER :: field_order, ierr, io, iu, i, pre, lun, nl_loc
     LOGICAL :: isnum
     INTEGER, DIMENSION(:), POINTER :: stride_temp
+    INTEGER :: sz
+    LOGICAL :: exists
+    CHARACTER(LEN=:), ALLOCATABLE :: dname, str
 
     errcode = c_err_none
 
@@ -282,6 +285,91 @@ CONTAINS
         END DO
       END IF
       CALL abort_code(c_err_bad_value)
+
+    ELSE IF (str_cmp(element, 'use_restart_dependency_file')) THEN
+      use_restart_dependency_file = as_logical_print(value, element, errcode)
+      IF (errcode /= c_err_none .OR. .NOT. use_restart_dependency_file) RETURN
+      IF (rank == 0) THEN
+        INQUIRE(FILE=TRIM(data_dir) // '/' // TRIM(restart_dependency_file), &
+           exist = exists, size = sz)
+        IF (.NOT. exists .OR. sz <= 0) THEN
+          CALL MPI_BCAST(0, 1, MPI_INTEGER, 0, comm, ierr)
+          RETURN
+        END IF
+        lun=get_free_lun()
+        OPEN(UNIT=lun,FILE=TRIM(data_dir) // '/' &
+            // TRIM(restart_dependency_file), ACCESS='STREAM', STATUS='OLD')
+        ALLOCATE(CHARACTER(LEN=sz)::str)
+        READ(lun) str
+        CLOSE(lun)
+        nl_loc = sz
+        DO WHILE(nl_loc > 0)
+          pre = INDEX(str(:nl_loc-1), NEW_LINE('A'), BACK = .TRUE.)
+          IF (pre < 1) pre = 0
+          IF (pre == nl_loc) CYCLE
+          ALLOCATE(dname, SOURCE = str(pre+1:nl_loc-1))
+          IF (dname == restart_terminate_string) THEN
+            DO iu = 1, nio_units ! Print to stdout and to file
+              io = io_units(iu)
+              WRITE(io,*) '*** INFO ***'
+              WRITE(io,*) 'Code has reached true end point so will not restart'
+            END DO
+            CALL abort_code(c_err_ended_restart)
+          END IF
+          INQUIRE(FILE = TRIM(data_dir) // '/' // dname, exist = exists)
+          IF (exists) EXIT
+          DEALLOCATE(dname)
+          nl_loc = pre
+        END DO
+        IF (.NOT. ALLOCATED(dname)) THEN
+          DO iu = 1, nio_units ! Print to stdout and to file
+            io = io_units(iu)
+            WRITE(io,*) '*** ERROR ***'
+            WRITE(io,*) 'Restart dependency file does not specify any valid'
+            WRITE(io,*) 'files for restart. This is a fatal error and EPOCH'
+            WRITE(io,*) 'will close'
+          END DO
+          CALL MPI_BCAST(-1, 1, MPI_INTEGER, 0, comm, ierr)
+          errcode = c_err_bad_value + c_err_terminate
+          RETURN
+        END IF
+        CALL MPI_BCAST(LEN(dname), 1, MPI_INTEGER, 0, comm, ierr)
+        CALL MPI_BCAST(dname, LEN(dname), MPI_CHARACTER, 0, comm, &
+            ierr)
+        restart_filename = dname
+        DEALLOCATE(dname, str)
+        ic_from_restart = .TRUE.
+      ELSE
+        CALL MPI_BCAST(sz, 1, MPI_INTEGER, 0, comm, ierr)
+        IF (sz == 0) RETURN
+        IF (sz < 0) THEN
+          errcode = c_err_bad_value + c_err_terminate
+          RETURN
+        END IF
+        ALLOCATE(CHARACTER(LEN=sz)::dname)
+        CALL MPI_BCAST(dname, LEN(dname), MPI_CHARACTER, 0, comm, &
+            ierr)
+        restart_filename = dname
+        DEALLOCATE(dname)
+        ic_from_restart = .TRUE.
+      END IF
+
+    ELSE IF (str_cmp(element, 'restart_snapshot')) THEN
+      isnum = .TRUE.
+      str_tmp = TRIM(ADJUSTL(value))
+      DO i = 1,LEN_TRIM(str_tmp)
+        c = str_tmp(i:i)
+        IF (c < '0' .OR. c > '9') THEN
+          isnum = .FALSE.
+          EXIT
+        END IF
+      END DO
+      IF (isnum) THEN
+        restart_number = as_integer_print(value, element, errcode)
+      ELSE
+        restart_filename = TRIM(str_tmp)
+      END IF
+      ic_from_restart = .TRUE.
 
     ELSE IF (str_cmp(element, 'restart_snapshot')) THEN
       isnum = .TRUE.

--- a/epoch2d/src/shared_data.F90
+++ b/epoch2d/src/shared_data.F90
@@ -282,6 +282,9 @@ MODULE shared_data
   INTEGER :: full_dump_every, restart_dump_every
   LOGICAL :: force_first_to_be_restartable
   LOGICAL :: force_final_to_be_restartable
+  LOGICAL :: use_restart_dependency_file = .FALSE.
+  CHARACTER(LEN=*), PARAMETER :: restart_dependency_file = 'restart.dep'
+  CHARACTER(LEN=*), PARAMETER :: restart_terminate_string = 'TERMINATE'
   LOGICAL :: use_offset_grid
   INTEGER :: n_zeros_control, n_zeros = 4
   INTEGER, DIMENSION(num_vars_to_dump) :: dumpmask

--- a/epoch3d/src/constants.F90
+++ b/epoch3d/src/constants.F90
@@ -103,6 +103,7 @@ MODULE constants
   INTEGER, PARAMETER :: c_err_io_error = 2**15
   INTEGER, PARAMETER :: c_err_bad_setup = 2**16
   INTEGER, PARAMETER :: c_err_window = 2**17
+  INTEGER, PARAMETER :: c_err_ended_restart = 2**18
 
   INTEGER, PARAMETER :: c_ds_first = 1
   INTEGER, PARAMETER :: c_ds_last = 2

--- a/epoch3d/src/deck/deck_control_block.F90
+++ b/epoch3d/src/deck/deck_control_block.F90
@@ -212,9 +212,12 @@ CONTAINS
     CHARACTER(LEN=string_length) :: str_tmp
     CHARACTER(LEN=1) :: c
     INTEGER :: errcode
-    INTEGER :: field_order, ierr, io, iu, i
+    INTEGER :: field_order, ierr, io, iu, i, pre, lun, nl_loc
     LOGICAL :: isnum
     INTEGER, DIMENSION(:), POINTER :: stride_temp
+    INTEGER :: sz
+    LOGICAL :: exists
+    CHARACTER(LEN=:), ALLOCATABLE :: dname, str
 
     errcode = c_err_none
 
@@ -300,6 +303,91 @@ CONTAINS
         END DO
       END IF
       CALL abort_code(c_err_bad_value)
+
+    ELSE IF (str_cmp(element, 'use_restart_dependency_file')) THEN
+      use_restart_dependency_file = as_logical_print(value, element, errcode)
+      IF (errcode /= c_err_none .OR. .NOT. use_restart_dependency_file) RETURN
+      IF (rank == 0) THEN
+        INQUIRE(FILE=TRIM(data_dir) // '/' // TRIM(restart_dependency_file), &
+           exist = exists, size = sz)
+        IF (.NOT. exists .OR. sz <= 0) THEN
+          CALL MPI_BCAST(0, 1, MPI_INTEGER, 0, comm, ierr)
+          RETURN
+        END IF
+        lun=get_free_lun()
+        OPEN(UNIT=lun,FILE=TRIM(data_dir) // '/' &
+            // TRIM(restart_dependency_file), ACCESS='STREAM', STATUS='OLD')
+        ALLOCATE(CHARACTER(LEN=sz)::str)
+        READ(lun) str
+        CLOSE(lun)
+        nl_loc = sz
+        DO WHILE(nl_loc > 0)
+          pre = INDEX(str(:nl_loc-1), NEW_LINE('A'), BACK = .TRUE.)
+          IF (pre < 1) pre = 0
+          IF (pre == nl_loc) CYCLE
+          ALLOCATE(dname, SOURCE = str(pre+1:nl_loc-1))
+          IF (dname == restart_terminate_string) THEN
+            DO iu = 1, nio_units ! Print to stdout and to file
+              io = io_units(iu)
+              WRITE(io,*) '*** INFO ***'
+              WRITE(io,*) 'Code has reached true end point so will not restart'
+            END DO
+            CALL abort_code(c_err_ended_restart)
+          END IF
+          INQUIRE(FILE = TRIM(data_dir) // '/' // dname, exist = exists)
+          IF (exists) EXIT
+          DEALLOCATE(dname)
+          nl_loc = pre
+        END DO
+        IF (.NOT. ALLOCATED(dname)) THEN
+          DO iu = 1, nio_units ! Print to stdout and to file
+            io = io_units(iu)
+            WRITE(io,*) '*** ERROR ***'
+            WRITE(io,*) 'Restart dependency file does not specify any valid'
+            WRITE(io,*) 'files for restart. This is a fatal error and EPOCH'
+            WRITE(io,*) 'will close'
+          END DO
+          CALL MPI_BCAST(-1, 1, MPI_INTEGER, 0, comm, ierr)
+          errcode = c_err_bad_value + c_err_terminate
+          RETURN
+        END IF
+        CALL MPI_BCAST(LEN(dname), 1, MPI_INTEGER, 0, comm, ierr)
+        CALL MPI_BCAST(dname, LEN(dname), MPI_CHARACTER, 0, comm, &
+            ierr)
+        restart_filename = dname
+        DEALLOCATE(dname, str)
+        ic_from_restart = .TRUE.
+      ELSE
+        CALL MPI_BCAST(sz, 1, MPI_INTEGER, 0, comm, ierr)
+        IF (sz == 0) RETURN
+        IF (sz < 0) THEN
+          errcode = c_err_bad_value + c_err_terminate
+          RETURN
+        END IF
+        ALLOCATE(CHARACTER(LEN=sz)::dname)
+        CALL MPI_BCAST(dname, LEN(dname), MPI_CHARACTER, 0, comm, &
+            ierr)
+        restart_filename = dname
+        DEALLOCATE(dname)
+        ic_from_restart = .TRUE.
+      END IF
+
+    ELSE IF (str_cmp(element, 'restart_snapshot')) THEN
+      isnum = .TRUE.
+      str_tmp = TRIM(ADJUSTL(value))
+      DO i = 1,LEN_TRIM(str_tmp)
+        c = str_tmp(i:i)
+        IF (c < '0' .OR. c > '9') THEN
+          isnum = .FALSE.
+          EXIT
+        END IF
+      END DO
+      IF (isnum) THEN
+        restart_number = as_integer_print(value, element, errcode)
+      ELSE
+        restart_filename = TRIM(str_tmp)
+      END IF
+      ic_from_restart = .TRUE.
 
     ELSE IF (str_cmp(element, 'restart_snapshot')) THEN
       isnum = .TRUE.

--- a/epoch3d/src/io/diagnostics.F90
+++ b/epoch3d/src/io/diagnostics.F90
@@ -216,12 +216,12 @@ CONTAINS
     REAL(num), DIMENSION(:,:,:), ALLOCATABLE :: array
     INTEGER, DIMENSION(2,c_ndims) :: ranges
     INTEGER :: code, i, io, ispecies, iprefix, mask, rn, dir, dumped, nval, n
-    INTEGER :: errcode
+    INTEGER :: errcode, lun
     INTEGER :: random_state(4)
     INTEGER, ALLOCATABLE :: random_states_per_proc(:)
     INTEGER, DIMENSION(c_ndims) :: dims
     INTEGER, SAVE :: nstep_prev = -1
-    LOGICAL :: convert, force, any_written, restart_id, print_arrays
+    LOGICAL :: convert, force, any_written, restart_id, print_arrays, exists
     LOGICAL, SAVE :: first_call = .TRUE.
     TYPE(particle_species), POINTER :: species
     TYPE(subset), POINTER :: sub
@@ -964,6 +964,25 @@ CONTAINS
       CALL sdf_close(sdf_handle)
 
       IF (rank == 0) THEN
+        IF (restart_flag .AND. use_restart_dependency_file) THEN
+          lun = get_free_lun()
+          INQUIRE(FILE=TRIM(data_dir) // '/' //restart_dependency_file, &
+              exist = exists)
+          IF (.NOT. exists) THEN
+            OPEN(UNIT=lun, FILE=TRIM(data_dir) // '/' &
+                // restart_dependency_file, FORM="FORMATTED", STATUS="NEW")
+          ELSE
+            OPEN(UNIT=lun, FILE=TRIM(data_dir) // '/' &
+                // restart_dependency_file, FORM="FORMATTED", STATUS="OLD", &
+                POSITION="APPEND")
+          END IF
+          WRITE(lun,'(A)') TRIM(filename)
+          IF ((step >= nsteps .AND. nsteps >= 0) .OR. (time >= t_end)) THEN
+            WRITE(lun,'(A)') restart_terminate_string
+          END IF
+          CLOSE(lun)
+        END IF
+
         DO io = 1, n_io_blocks
           IF (io_block_list(io)%dump) THEN
             dump_type = TRIM(io_block_list(io)%name)

--- a/epoch3d/src/shared_data.F90
+++ b/epoch3d/src/shared_data.F90
@@ -283,6 +283,9 @@ MODULE shared_data
   INTEGER :: full_dump_every, restart_dump_every
   LOGICAL :: force_first_to_be_restartable
   LOGICAL :: force_final_to_be_restartable
+  LOGICAL :: use_restart_dependency_file = .FALSE.
+  CHARACTER(LEN=*), PARAMETER :: restart_dependency_file = 'restart.dep'
+  CHARACTER(LEN=*), PARAMETER :: restart_terminate_string = 'TERMINATE'
   LOGICAL :: use_offset_grid
   INTEGER :: n_zeros_control, n_zeros = 4
   INTEGER, DIMENSION(num_vars_to_dump) :: dumpmask


### PR DESCRIPTION
In GitLab by Christopher Brady (@csbrady-warwick) on 30 Jul 2020, 17:32  (GitLab merge request GL#369)

This MR introduces a new logical deck key `use_restart_dependency_file` that specifies that EPOCH should write a file that specifies which was the last restart dump written and on starting try to read that file and restart from it. Fixes issue GL#2221