### PR TITLE
Angular bremsstrahlung emissions

### DIFF
--- a/epoch1d/Makefile
+++ b/epoch1d/Makefile
@@ -446,7 +446,7 @@ balance.o: balance.F90 boundary.o constants.o mpi_subtype_control.o \
   redblack_module.o timer.o utilities.o
 boundary.o: boundary.F90 injectors.o laser.o mpi_subtype_control.o \
   particle_id_hash.o particle_temperature.o partlist.o utilities.o
-bremsstrahlung.o: bremsstrahlung.F90 calc_df.o partlist.o setup.o
+bremsstrahlung.o: bremsstrahlung.F90 calc_df.o particles.o partlist.o setup.o
 calc_df.o: calc_df.F90 boundary.o
 collisions.o: collisions.F90 calc_df.o prefetch.o
 constants.o: constants.F90 $(SDFMOD)

--- a/epoch1d/src/constants.F90
+++ b/epoch1d/src/constants.F90
@@ -194,7 +194,7 @@ MODULE constants
       atomic_electric_field = 5.142206538736485312185213306837419e11_num
   ! m0 * c
   REAL(num), PARAMETER :: mc0 = 2.73092429345209278e-22_num
-  ! m0 * c²
+  ! m0 * c**2
   REAL(num), PARAMETER :: m0c2 = mc0 * c
 
   ! Constants used in pair production

--- a/epoch1d/src/constants.F90
+++ b/epoch1d/src/constants.F90
@@ -194,6 +194,8 @@ MODULE constants
       atomic_electric_field = 5.142206538736485312185213306837419e11_num
   ! m0 * c
   REAL(num), PARAMETER :: mc0 = 2.73092429345209278e-22_num
+  ! m0 * c²
+  REAL(num), PARAMETER :: m0c2 = mc0 * c
 
   ! Constants used in pair production
 #ifdef PHOTONS

--- a/epoch1d/src/deck/deck_bremsstrahlung_block.F90
+++ b/epoch1d/src/deck/deck_bremsstrahlung_block.F90
@@ -174,6 +174,11 @@ CONTAINS
       RETURN
     END IF
 
+    IF (str_cmp(element, 'use_brem_scatter')) THEN
+      use_brem_scatter = as_logical_print(value, element, errcode)
+      RETURN
+    END IF
+
     errcode = c_err_unknown_element
 #endif
 

--- a/epoch1d/src/deck/deck_bremsstrahlung_block.F90
+++ b/epoch1d/src/deck/deck_bremsstrahlung_block.F90
@@ -174,7 +174,8 @@ CONTAINS
       RETURN
     END IF
 
-    IF (str_cmp(element, 'use_brem_scatter')) THEN
+    IF (str_cmp(element, 'use_brem_scatter') &
+        .OR. str_cmp(element, 'use_bremsstrahlung_scatter')) THEN
       use_brem_scatter = as_logical_print(value, element, errcode)
       RETURN
     END IF

--- a/epoch1d/src/particles.F90
+++ b/epoch1d/src/particles.F90
@@ -756,9 +756,9 @@ CONTAINS
     frac_p = 1.0_num / p
 
     ! Precalculate repeated terms
-    pcos_theta = p * cos_theta
     sin_theta = SQRT(1.0_num - cos_theta**2)
-    psin_theta = p*sin_theta
+    pcos_theta = p * cos_theta
+    psin_theta = p * sin_theta
     uz = part%part_p(3) * frac_p
 
     IF (ABS(1.0_num - uz) < 1.0e-10_num) THEN
@@ -770,10 +770,10 @@ CONTAINS
       ! Precalculate repeated terms
       ux = part%part_p(1) * frac_p
       uy = part%part_p(2) * frac_p
-      pfrac_uz = p/SQRT(1.0_num - uz**2)
+      pfrac_uz = p / SQRT(1.0_num - uz**2)
       cos_phi = COS(phi)
-      term_1 = sin_theta*cos_phi*uz*pfrac_uz + pcos_theta
-      term_2 = sin_theta*SIN(phi)*pfrac_uz
+      term_1 = sin_theta * cos_phi * uz * pfrac_uz + pcos_theta
+      term_2 = sin_theta * SIN(phi) * pfrac_uz
 
       part%part_p(1) = ux * term_1 - uy * term_2
       part%part_p(2) = uy * term_1 + ux * term_2

--- a/epoch1d/src/particles.F90
+++ b/epoch1d/src/particles.F90
@@ -728,4 +728,59 @@ CONTAINS
   END SUBROUTINE push_photons
 #endif
 
+
+
+  SUBROUTINE rotate_p(part, cos_theta, phi, part_p)
+
+    ! Let the polar axis be defined as the initial momentum direction of the
+    ! particle, part. This subroutine rotates that momentum direction by the
+    ! polar angle theta (we read in cos(theta)), and the azimuthal angle phi,
+    ! without changing the magnitude.
+    !
+    ! If we have already calculated the magnitude of the particle's momentum,
+    ! part_p, this can also be fed into the subroutine to speed up the
+    ! calculation
+
+    TYPE(particle), POINTER :: part
+    REAL(num), INTENT(IN) :: cos_theta, phi
+    REAL(num), OPTIONAL :: part_p
+    REAL(num) :: p, frac_p, pcos_theta, sin_theta, psin_theta
+    REAL(num) :: ux, uy, uz, pfrac_uz, cos_phi, term_1, term_2
+
+    ! Extract particle momentum
+    IF (PRESENT(part_p)) THEN
+      p = part_p
+    ELSE
+      p = SQRT(part%part_p(1)**2 + part%part_p(2)**2 + part%part_p(3)**2)
+    END IF
+    frac_p = 1.0_num / p
+
+    ! Precalculate repeated terms
+    pcos_theta = p * cos_theta
+    sin_theta = SQRT(1.0_num - cos_theta**2)
+    psin_theta = p*sin_theta
+    uz = part%part_p(3) * frac_p
+
+    IF (ABS(1.0_num - uz) < 1.0e-10_num) THEN
+      ! Special case if the polar direction points along z
+      part%part_p(1) = psin_theta * COS(phi)
+      part%part_p(2) = psin_theta * SIN(phi)
+      part%part_p(3) = pcos_theta * SIGN(1.0_num, uz)
+    ELSE
+      ! Precalculate repeated terms
+      ux = part%part_p(1) * frac_p
+      uy = part%part_p(2) * frac_p
+      pfrac_uz = p/SQRT(1.0_num - uz**2)
+      cos_phi = COS(phi)
+      term_1 = sin_theta*cos_phi*uz*pfrac_uz + pcos_theta
+      term_2 = sin_theta*SIN(phi)*pfrac_uz
+
+      part%part_p(1) = ux * term_1 - uy * term_2
+      part%part_p(2) = uy * term_1 + ux * term_2
+      part%part_p(3) = uz * pcos_theta &
+          + cos_phi * sin_theta * (uz**2 - 1.0_num) * pfrac_uz
+    END IF
+
+  END SUBROUTINE rotate_p
+
 END MODULE particles

--- a/epoch1d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch1d/src/physics_packages/bremsstrahlung.F90
@@ -695,15 +695,15 @@ CONTAINS
     ! added into the simulation
     IF (use_brem_scatter .AND. add_photon) THEN
       scatter_theta = calc_scatter_theta(part_e)
-      scatter_phi = 2.0_num*pi*random()
+      scatter_phi = 2.0_num * pi * random()
       CALL rotate_p(new_photon, COS(scatter_theta), scatter_phi, photon_p)
     END IF
 
     ! Calculate electron recoil (subtract weighted photon momentum)
     IF (use_bremsstrahlung_recoil) THEN
-      electron%part_p = electron%part_p - photon_weight*new_photon%part_p
+      electron%part_p = electron%part_p - photon_weight * new_photon%part_p
       electron%particle_energy = electron%particle_energy &
-          - (photon_weight*photon_energy)
+          - photon_weight * photon_energy
     END IF
 
     ! This will only create photons that have energies above a user specified
@@ -739,14 +739,14 @@ CONTAINS
 
     REAL(num), INTENT(IN) :: part_E
     REAL(num) :: calc_scatter_theta
-    REAL(num) :: gamma_theta_max, gamma_theta, gamma
+    REAL(num) :: gamma_theta_max, gamma_theta, gamma_rel
     REAL(num) :: a1 = 0.625_num
     REAL(num) :: a2 = 1.875_num
     REAL(num) :: border = 0.25_num
     REAL(num) :: r1, r2, r3
 
-    gamma = part_E/(m0c2)
-    gamma_theta_max = pi*gamma
+    gamma_rel = part_E / m0c2
+    gamma_theta_max = pi * gamma_rel
 
     ! Perform the Tsai algorithm
     DO
@@ -758,16 +758,16 @@ CONTAINS
       ! Random sampling returns a u value, which is equivalent to the product of
       ! the particle gamma factor and the deflection theta
       IF (r1 < border) THEN
-        gamma_theta = -LOG(r2*r3)/a1
+        gamma_theta = -LOG(r2 * r3) / a1
       ELSE
-        gamma_theta = -LOG(r2*r3)/a2
+        gamma_theta = -LOG(r2 * r3) / a2
       END IF
 
       ! We require a theta value less than pi
       IF (gamma_theta <= gamma_theta_max) EXIT
     END DO
 
-    calc_scatter_theta = gamma_theta/gamma
+    calc_scatter_theta = gamma_theta / gamma_rel
 
   END FUNCTION calc_scatter_theta
 

--- a/epoch1d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch1d/src/physics_packages/bremsstrahlung.F90
@@ -654,8 +654,10 @@ CONTAINS
     INTEGER, INTENT(IN) :: iphoton, z
     INTEGER :: brem_index
     REAL(num) :: dir_x, dir_y, dir_z, mag_p
-    REAL(num) :: rand_temp, photon_energy, part_e
+    REAL(num) :: rand_temp, photon_energy, photon_p, part_e
+    REAL(num) :: scatter_theta, scatter_phi
     TYPE(particle), POINTER :: new_photon
+    LOGICAL :: add_photon
 
     ! Obtain electron direction (magnitude must be > 0 to prevent 1/0 issues)
     part_e = electron%particle_energy
@@ -673,42 +675,103 @@ CONTAINS
         brem_array(brem_index)%e_table, brem_array(brem_index)%k_table, &
         brem_array(brem_index)%cdf_table, brem_array(brem_index)%state)
 
-    ! Calculate electron recoil
+    ! Is this photon to be added into the simulation?
+    add_photon = (photon_energy > photon_energy_min_bremsstrahlung &
+        .AND. produce_bremsstrahlung_photons)
+
+    ! Ensure photon_energy is a number we can handle at our precision
+    IF (photon_energy < c_tiny) photon_energy = c_tiny
+
+    ! Temporarily store photon momentum in the "new_photon" particle
+    CALL create_particle(new_photon)
+    photon_p = photon_energy / c
+    new_photon%part_p(1) = dir_x * photon_p
+    new_photon%part_p(2) = dir_y * photon_p
+    new_photon%part_p(3) = dir_z * photon_p
+
+    ! Rotate photon according to bremsstrahlung emission angular distribution
+    ! Only consider trajectory changes from e- with high enough energy to be
+    ! added into the simulation
+    IF (use_brem_scatter .AND. add_photon) THEN
+      scatter_theta = calc_scatter_theta(part_e)
+      scatter_phi = 2.0_num*pi*random()
+      CALL rotate_p(new_photon, COS(scatter_theta), scatter_phi, photon_p)
+    END IF
+
+    ! Calculate electron recoil (subtract weighted photon momentum)
     IF (use_bremsstrahlung_recoil) THEN
-      mag_p = mag_p - photon_weight * photon_energy / c
-      electron%part_p(1) = dir_x * mag_p
-      electron%part_p(2) = dir_y * mag_p
-      electron%part_p(3) = dir_z * mag_p
-      electron%particle_energy = electron%particle_energy - photon_energy
+      electron%part_p = electron%part_p - photon_weight*new_photon%part_p
+      electron%particle_energy = electron%particle_energy &
+          - (photon_weight*photon_energy)
     END IF
 
     ! This will only create photons that have energies above a user specified
     ! cutoff and if photon generation is turned on.
-    IF (photon_energy > photon_energy_min_bremsstrahlung &
-        .AND. produce_bremsstrahlung_photons) THEN
-      ! Ensure photon_energy is a number we can handle at our precision
-      IF (photon_energy < c_tiny) photon_energy = c_tiny
-
-      ! Create new photon at the electron position, in the electron direction
-      CALL create_particle(new_photon)
+    IF (add_photon) THEN
+      ! Create new photon at the electron position,
       new_photon%part_pos = electron%part_pos
-      new_photon%part_p(1) = dir_x * photon_energy / c
-      new_photon%part_p(2) = dir_y * photon_energy / c
-      new_photon%part_p(3) = dir_z * photon_energy / c
+
 #ifdef PHOTONS
       new_photon%optical_depth = reset_optical_depth()
 #endif
       new_photon%particle_energy = photon_energy
       new_photon%weight = electron%weight * photon_weight
 
+      ! Add photon to its species
       CALL add_particle_to_partlist(species_list(iphoton)%attached_list, &
           new_photon)
+    ELSE
+      ! We are not adding the photon to the simulation
+      CALL destroy_particle(new_photon)
     END IF
 
   END SUBROUTINE generate_photon
 
 
 
+  ! Calculates the angular scatter of photons using the Tsai method outlined in
+  ! the Geant4 physics reference manual, section 10.2.1. This model is accurate
+  ! for electron energies over 500 keV (as discussed in the "Comparisons
+  ! between Tsai, 2BS and 2BN generators" section)
+
+  FUNCTION calc_scatter_theta(part_E)
+
+    REAL(num), INTENT(IN) :: part_E
+    REAL(num) :: calc_scatter_theta
+    REAL(num) :: gamma_theta_max, gamma_theta, gamma
+    REAL(num) :: a1 = 0.625_num
+    REAL(num) :: a2 = 1.875_num
+    REAL(num) :: border = 0.25_num
+    REAL(num) :: r1, r2, r3
+
+    gamma = part_E/(mc2)
+    gamma_theta_max = pi*gamma
+
+    ! Perform the Tsai algorithm
+    DO
+      ! We require three random numbers per sample attempt
+      r1 = random()
+      r2 = random()
+      r3 = random()
+
+      ! Random sampling returns a u value, which is equivalent to the product of
+      ! the particle gamma factor and the deflection theta
+      IF (r1 < border) THEN
+        gamma_theta = -LOG(r2*r3)/a1
+      ELSE
+        gamma_theta = -LOG(r2*r3)/a2
+      END IF
+
+      ! We require a theta value less than pi
+      IF (gamma_theta <= gamma_theta_max) EXIT
+    END DO
+
+    calc_scatter_theta = gamma_theta/gamma
+
+  END FUNCTION calc_scatter_theta
+
+
+  
   ! Calculates the value of a grid-centred variable part_var stored in the grid
   ! grid_var, averaged over the particle shape for a particle at position
   ! part_x

--- a/epoch1d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch1d/src/physics_packages/bremsstrahlung.F90
@@ -17,6 +17,7 @@ MODULE bremsstrahlung
 #ifdef BREMSSTRAHLUNG
 
   USE partlist
+  USE particles
   USE calc_df
   USE setup
 
@@ -730,9 +731,9 @@ CONTAINS
 
 
   ! Calculates the angular scatter of photons using the Tsai method outlined in
-  ! the Geant4 physics reference manual, section 10.2.1. This model is accurate
-  ! for electron energies over 500 keV (as discussed in the "Comparisons
-  ! between Tsai, 2BS and 2BN generators" section)
+  ! the Geant4 physics reference manual (release 10.6, section 10.2.1). This
+  ! model is accurate for electron energies over 500 keV (as discussed in the
+  ! "Comparisons between Tsai, 2BS and 2BN generators" section)
 
   FUNCTION calc_scatter_theta(part_E)
 
@@ -744,7 +745,7 @@ CONTAINS
     REAL(num) :: border = 0.25_num
     REAL(num) :: r1, r2, r3
 
-    gamma = part_E/(mc2)
+    gamma = part_E/(m0c2)
     gamma_theta_max = pi*gamma
 
     ! Perform the Tsai algorithm
@@ -771,7 +772,7 @@ CONTAINS
   END FUNCTION calc_scatter_theta
 
 
-  
+
   ! Calculates the value of a grid-centred variable part_var stored in the grid
   ! grid_var, averaged over the particle shape for a particle at position
   ! part_x

--- a/epoch1d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch1d/src/physics_packages/bremsstrahlung.F90
@@ -646,8 +646,13 @@ CONTAINS
 
 
 
-  ! Generates a photon moving in same direction as the electron, calculating
-  ! electron recoil if appropriate
+  ! Generates a photon at the same position as the electron "electron". Emission
+  ! was triggered due to electron interaction with a nucleus of atomic number z,
+  ! and the photon is written to the species with ID iphoton if appropriate.
+  ! Photon energy is sampled from bremsstrahlung tables, and momentum is either
+  ! parallel to the electron momentum (without brem_scatter), or scattered by
+  ! angles drawn from the bremsstrahlung differential cross section (with
+  ! brem_scatter). Electron recoil is applied if requested.
 
   SUBROUTINE generate_photon(electron, z, iphoton)
 

--- a/epoch1d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch1d/src/physics_packages/bremsstrahlung.F90
@@ -693,7 +693,8 @@ CONTAINS
     ! Rotate photon according to bremsstrahlung emission angular distribution
     ! Only consider trajectory changes from e- with high enough energy to be
     ! added into the simulation
-    IF (use_brem_scatter .AND. add_photon) THEN
+    IF (photon_energy > photon_energy_min_bremsstrahlung &
+        .AND. use_brem_scatter) THEN
       scatter_theta = calc_scatter_theta(part_e)
       scatter_phi = 2.0_num * pi * random()
       CALL rotate_p(new_photon, COS(scatter_theta), scatter_phi, photon_p)

--- a/epoch1d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch1d/src/physics_packages/bremsstrahlung.F90
@@ -746,9 +746,9 @@ CONTAINS
     REAL(num), INTENT(IN) :: part_E
     REAL(num) :: calc_scatter_theta
     REAL(num) :: gamma_theta_max, gamma_theta, gamma_rel
-    REAL(num) :: a1 = 0.625_num
-    REAL(num) :: a2 = 1.875_num
-    REAL(num) :: border = 0.25_num
+    REAL(num), PARAMETER :: a1 = 0.625_num
+    REAL(num), PARAMETER :: a2 = 1.875_num
+    REAL(num), PARAMETER :: border = 0.25_num
     REAL(num) :: r1, r2, r3
 
     gamma_rel = part_E / m0c2

--- a/epoch1d/src/shared_data.F90
+++ b/epoch1d/src/shared_data.F90
@@ -601,6 +601,7 @@ MODULE shared_data
   LOGICAL :: produce_bremsstrahlung_photons = .FALSE.
   LOGICAL :: bremsstrahlung_photon_dynamics = .FALSE.
   LOGICAL :: use_plasma_screening = .FALSE.
+  LOGICAL :: use_brem_scatter = .FALSE.
   CHARACTER(LEN=string_length) :: bremsstrahlung_table_location
 #endif
   LOGICAL :: use_bremsstrahlung = .FALSE.

--- a/epoch2d/Makefile
+++ b/epoch2d/Makefile
@@ -446,7 +446,7 @@ balance.o: balance.F90 boundary.o constants.o mpi_subtype_control.o \
   redblack_module.o timer.o utilities.o
 boundary.o: boundary.F90 injectors.o laser.o mpi_subtype_control.o \
   particle_id_hash.o particle_temperature.o partlist.o utilities.o
-bremsstrahlung.o: bremsstrahlung.F90 calc_df.o partlist.o setup.o
+bremsstrahlung.o: bremsstrahlung.F90 calc_df.o particles.o partlist.o setup.o
 calc_df.o: calc_df.F90 boundary.o
 collisions.o: collisions.F90 calc_df.o prefetch.o
 constants.o: constants.F90 $(SDFMOD)

--- a/epoch2d/src/constants.F90
+++ b/epoch2d/src/constants.F90
@@ -194,7 +194,7 @@ MODULE constants
       atomic_electric_field = 5.142206538736485312185213306837419e11_num
   ! m0 * c
   REAL(num), PARAMETER :: mc0 = 2.73092429345209278e-22_num
-  ! m0 * c²
+  ! m0 * c**2
   REAL(num), PARAMETER :: m0c2 = mc0 * c
 
   ! Constants used in pair production

--- a/epoch2d/src/constants.F90
+++ b/epoch2d/src/constants.F90
@@ -194,6 +194,8 @@ MODULE constants
       atomic_electric_field = 5.142206538736485312185213306837419e11_num
   ! m0 * c
   REAL(num), PARAMETER :: mc0 = 2.73092429345209278e-22_num
+  ! m0 * c²
+  REAL(num), PARAMETER :: m0c2 = mc0 * c
 
   ! Constants used in pair production
 #ifdef PHOTONS

--- a/epoch2d/src/deck/deck_bremsstrahlung_block.F90
+++ b/epoch2d/src/deck/deck_bremsstrahlung_block.F90
@@ -174,6 +174,11 @@ CONTAINS
       RETURN
     END IF
 
+    IF (str_cmp(element, 'use_brem_scatter')) THEN
+      use_brem_scatter = as_logical_print(value, element, errcode)
+      RETURN
+    END IF
+
     errcode = c_err_unknown_element
 #endif
 

--- a/epoch2d/src/deck/deck_bremsstrahlung_block.F90
+++ b/epoch2d/src/deck/deck_bremsstrahlung_block.F90
@@ -174,7 +174,8 @@ CONTAINS
       RETURN
     END IF
 
-    IF (str_cmp(element, 'use_brem_scatter')) THEN
+    IF (str_cmp(element, 'use_brem_scatter') &
+        .OR. str_cmp(element, 'use_bremsstrahlung_scatter')) THEN
       use_brem_scatter = as_logical_print(value, element, errcode)
       RETURN
     END IF

--- a/epoch2d/src/particles.F90
+++ b/epoch2d/src/particles.F90
@@ -821,4 +821,59 @@ CONTAINS
   END SUBROUTINE push_photons
 #endif
 
+
+
+  SUBROUTINE rotate_p(part, cos_theta, phi, part_p)
+
+    ! Let the polar axis be defined as the initial momentum direction of the
+    ! particle, part. This subroutine rotates that momentum direction by the
+    ! polar angle theta (we read in cos(theta)), and the azimuthal angle phi,
+    ! without changing the magnitude.
+    !
+    ! If we have already calculated the magnitude of the particle's momentum,
+    ! part_p, this can also be fed into the subroutine to speed up the
+    ! calculation
+
+    TYPE(particle), POINTER :: part
+    REAL(num), INTENT(IN) :: cos_theta, phi
+    REAL(num), OPTIONAL :: part_p
+    REAL(num) :: p, frac_p, pcos_theta, sin_theta, psin_theta
+    REAL(num) :: ux, uy, uz, pfrac_uz, cos_phi, term_1, term_2
+
+    ! Extract particle momentum
+    IF (PRESENT(part_p)) THEN
+      p = part_p
+    ELSE
+      p = SQRT(part%part_p(1)**2 + part%part_p(2)**2 + part%part_p(3)**2)
+    END IF
+    frac_p = 1.0_num / p
+
+    ! Precalculate repeated terms
+    pcos_theta = p * cos_theta
+    sin_theta = SQRT(1.0_num - cos_theta**2)
+    psin_theta = p*sin_theta
+    uz = part%part_p(3) * frac_p
+
+    IF (ABS(1.0_num - uz) < 1.0e-10_num) THEN
+      ! Special case if the polar direction points along z
+      part%part_p(1) = psin_theta * COS(phi)
+      part%part_p(2) = psin_theta * SIN(phi)
+      part%part_p(3) = pcos_theta * SIGN(1.0_num, uz)
+    ELSE
+      ! Precalculate repeated terms
+      ux = part%part_p(1) * frac_p
+      uy = part%part_p(2) * frac_p
+      pfrac_uz = p/SQRT(1.0_num - uz**2)
+      cos_phi = COS(phi)
+      term_1 = sin_theta*cos_phi*uz*pfrac_uz + pcos_theta
+      term_2 = sin_theta*SIN(phi)*pfrac_uz
+
+      part%part_p(1) = ux * term_1 - uy * term_2
+      part%part_p(2) = uy * term_1 + ux * term_2
+      part%part_p(3) = uz * pcos_theta &
+          + cos_phi * sin_theta * (uz**2 - 1.0_num) * pfrac_uz
+    END IF
+
+  END SUBROUTINE rotate_p
+
 END MODULE particles

--- a/epoch2d/src/particles.F90
+++ b/epoch2d/src/particles.F90
@@ -849,9 +849,9 @@ CONTAINS
     frac_p = 1.0_num / p
 
     ! Precalculate repeated terms
-    pcos_theta = p * cos_theta
     sin_theta = SQRT(1.0_num - cos_theta**2)
-    psin_theta = p*sin_theta
+    pcos_theta = p * cos_theta
+    psin_theta = p * sin_theta
     uz = part%part_p(3) * frac_p
 
     IF (ABS(1.0_num - uz) < 1.0e-10_num) THEN
@@ -863,10 +863,10 @@ CONTAINS
       ! Precalculate repeated terms
       ux = part%part_p(1) * frac_p
       uy = part%part_p(2) * frac_p
-      pfrac_uz = p/SQRT(1.0_num - uz**2)
+      pfrac_uz = p / SQRT(1.0_num - uz**2)
       cos_phi = COS(phi)
-      term_1 = sin_theta*cos_phi*uz*pfrac_uz + pcos_theta
-      term_2 = sin_theta*SIN(phi)*pfrac_uz
+      term_1 = sin_theta * cos_phi * uz * pfrac_uz + pcos_theta
+      term_2 = sin_theta * SIN(phi) * pfrac_uz
 
       part%part_p(1) = ux * term_1 - uy * term_2
       part%part_p(2) = uy * term_1 + ux * term_2

--- a/epoch2d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch2d/src/physics_packages/bremsstrahlung.F90
@@ -698,15 +698,15 @@ CONTAINS
     ! added into the simulation
     IF (use_brem_scatter .AND. add_photon) THEN
       scatter_theta = calc_scatter_theta(part_e)
-      scatter_phi = 2.0_num*pi*random()
+      scatter_phi = 2.0_num * pi * random()
       CALL rotate_p(new_photon, COS(scatter_theta), scatter_phi, photon_p)
     END IF
 
     ! Calculate electron recoil (subtract weighted photon momentum)
     IF (use_bremsstrahlung_recoil) THEN
-      electron%part_p = electron%part_p - photon_weight*new_photon%part_p
+      electron%part_p = electron%part_p - photon_weight * new_photon%part_p
       electron%particle_energy = electron%particle_energy &
-          - (photon_weight*photon_energy)
+          - photon_weight * photon_energy
     END IF
 
     ! This will only create photons that have energies above a user specified
@@ -742,14 +742,14 @@ CONTAINS
 
     REAL(num), INTENT(IN) :: part_E
     REAL(num) :: calc_scatter_theta
-    REAL(num) :: gamma_theta_max, gamma_theta, gamma
+    REAL(num) :: gamma_theta_max, gamma_theta, gamma_rel
     REAL(num) :: a1 = 0.625_num
     REAL(num) :: a2 = 1.875_num
     REAL(num) :: border = 0.25_num
     REAL(num) :: r1, r2, r3
 
-    gamma = part_E/(m0c2)
-    gamma_theta_max = pi*gamma
+    gamma_rel = part_E / m0c2
+    gamma_theta_max = pi * gamma_rel
 
     ! Perform the Tsai algorithm
     DO
@@ -761,16 +761,16 @@ CONTAINS
       ! Random sampling returns a u value, which is equivalent to the product of
       ! the particle gamma factor and the deflection theta
       IF (r1 < border) THEN
-        gamma_theta = -LOG(r2*r3)/a1
+        gamma_theta = -LOG(r2 * r3) / a1
       ELSE
-        gamma_theta = -LOG(r2*r3)/a2
+        gamma_theta = -LOG(r2 * r3) / a2
       END IF
 
       ! We require a theta value less than pi
       IF (gamma_theta <= gamma_theta_max) EXIT
     END DO
 
-    calc_scatter_theta = gamma_theta/gamma
+    calc_scatter_theta = gamma_theta / gamma_rel
 
   END FUNCTION calc_scatter_theta
 

--- a/epoch2d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch2d/src/physics_packages/bremsstrahlung.F90
@@ -17,6 +17,7 @@ MODULE bremsstrahlung
 #ifdef BREMSSTRAHLUNG
 
   USE partlist
+  USE particles
   USE calc_df
   USE setup
 
@@ -733,9 +734,9 @@ CONTAINS
 
 
   ! Calculates the angular scatter of photons using the Tsai method outlined in
-  ! the Geant4 physics reference manual, section 10.2.1. This model is accurate
-  ! for electron energies over 500 keV (as discussed in the "Comparisons
-  ! between Tsai, 2BS and 2BN generators" section)
+  ! the Geant4 physics reference manual (release 10.6, section 10.2.1). This
+  ! model is accurate for electron energies over 500 keV (as discussed in the
+  ! "Comparisons between Tsai, 2BS and 2BN generators" section)
 
   FUNCTION calc_scatter_theta(part_E)
 
@@ -747,7 +748,7 @@ CONTAINS
     REAL(num) :: border = 0.25_num
     REAL(num) :: r1, r2, r3
 
-    gamma = part_E/(mc2)
+    gamma = part_E/(m0c2)
     gamma_theta_max = pi*gamma
 
     ! Perform the Tsai algorithm

--- a/epoch2d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch2d/src/physics_packages/bremsstrahlung.F90
@@ -749,9 +749,9 @@ CONTAINS
     REAL(num), INTENT(IN) :: part_E
     REAL(num) :: calc_scatter_theta
     REAL(num) :: gamma_theta_max, gamma_theta, gamma_rel
-    REAL(num) :: a1 = 0.625_num
-    REAL(num) :: a2 = 1.875_num
-    REAL(num) :: border = 0.25_num
+    REAL(num), PARAMETER :: a1 = 0.625_num
+    REAL(num), PARAMETER :: a2 = 1.875_num
+    REAL(num), PARAMETER :: border = 0.25_num
     REAL(num) :: r1, r2, r3
 
     gamma_rel = part_E / m0c2

--- a/epoch2d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch2d/src/physics_packages/bremsstrahlung.F90
@@ -649,9 +649,14 @@ CONTAINS
 
 
 
-  ! Generates a photon moving in same direction as the electron, calculating
-  ! electron recoil if appropriate
-
+  ! Generates a photon at the same position as the electron "electron". Emission
+  ! was triggered due to electron interaction with a nucleus of atomic number z,
+  ! and the photon is written to the species with ID iphoton if appropriate.
+  ! Photon energy is sampled from bremsstrahlung tables, and momentum is either
+  ! parallel to the electron momentum (without brem_scatter), or scattered by
+  ! angles drawn from the bremsstrahlung differential cross section (with
+  ! brem_scatter). Electron recoil is applied if requested.
+  
   SUBROUTINE generate_photon(electron, z, iphoton)
 
     TYPE(particle), POINTER :: electron

--- a/epoch2d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch2d/src/physics_packages/bremsstrahlung.F90
@@ -696,7 +696,8 @@ CONTAINS
     ! Rotate photon according to bremsstrahlung emission angular distribution
     ! Only consider trajectory changes from e- with high enough energy to be
     ! added into the simulation
-    IF (use_brem_scatter .AND. add_photon) THEN
+    IF (photon_energy > photon_energy_min_bremsstrahlung &
+        .AND. use_brem_scatter) THEN
       scatter_theta = calc_scatter_theta(part_e)
       scatter_phi = 2.0_num * pi * random()
       CALL rotate_p(new_photon, COS(scatter_theta), scatter_phi, photon_p)

--- a/epoch2d/src/shared_data.F90
+++ b/epoch2d/src/shared_data.F90
@@ -625,6 +625,7 @@ MODULE shared_data
   LOGICAL :: produce_bremsstrahlung_photons = .FALSE.
   LOGICAL :: bremsstrahlung_photon_dynamics = .FALSE.
   LOGICAL :: use_plasma_screening = .FALSE.
+  LOGICAL :: use_brem_scatter = .FALSE.
   CHARACTER(LEN=string_length) :: bremsstrahlung_table_location
 #endif
   LOGICAL :: use_bremsstrahlung = .FALSE.

--- a/epoch3d/Makefile
+++ b/epoch3d/Makefile
@@ -446,7 +446,7 @@ balance.o: balance.F90 boundary.o constants.o mpi_subtype_control.o \
   redblack_module.o timer.o utilities.o
 boundary.o: boundary.F90 injectors.o laser.o mpi_subtype_control.o \
   particle_id_hash.o particle_temperature.o partlist.o utilities.o
-bremsstrahlung.o: bremsstrahlung.F90 calc_df.o partlist.o setup.o
+bremsstrahlung.o: bremsstrahlung.F90 calc_df.o particles.o partlist.o setup.o
 calc_df.o: calc_df.F90 boundary.o
 collisions.o: collisions.F90 calc_df.o prefetch.o
 constants.o: constants.F90 $(SDFMOD)

--- a/epoch3d/src/constants.F90
+++ b/epoch3d/src/constants.F90
@@ -194,7 +194,7 @@ MODULE constants
       atomic_electric_field = 5.142206538736485312185213306837419e11_num
   ! m0 * c
   REAL(num), PARAMETER :: mc0 = 2.73092429345209278e-22_num
-  ! m0 * c²
+  ! m0 * c**2
   REAL(num), PARAMETER :: m0c2 = mc0 * c
 
   ! Constants used in pair production

--- a/epoch3d/src/constants.F90
+++ b/epoch3d/src/constants.F90
@@ -194,6 +194,8 @@ MODULE constants
       atomic_electric_field = 5.142206538736485312185213306837419e11_num
   ! m0 * c
   REAL(num), PARAMETER :: mc0 = 2.73092429345209278e-22_num
+  ! m0 * c²
+  REAL(num), PARAMETER :: m0c2 = mc0 * c
 
   ! Constants used in pair production
 #ifdef PHOTONS

--- a/epoch3d/src/deck/deck_bremsstrahlung_block.F90
+++ b/epoch3d/src/deck/deck_bremsstrahlung_block.F90
@@ -174,6 +174,11 @@ CONTAINS
       RETURN
     END IF
 
+    IF (str_cmp(element, 'use_brem_scatter')) THEN
+      use_brem_scatter = as_logical_print(value, element, errcode)
+      RETURN
+    END IF
+
     errcode = c_err_unknown_element
 #endif
 

--- a/epoch3d/src/deck/deck_bremsstrahlung_block.F90
+++ b/epoch3d/src/deck/deck_bremsstrahlung_block.F90
@@ -174,7 +174,8 @@ CONTAINS
       RETURN
     END IF
 
-    IF (str_cmp(element, 'use_brem_scatter')) THEN
+    IF (str_cmp(element, 'use_brem_scatter') &
+        .OR. str_cmp(element, 'use_bremsstrahlung_scatter')) THEN
       use_brem_scatter = as_logical_print(value, element, errcode)
       RETURN
     END IF

--- a/epoch3d/src/particles.F90
+++ b/epoch3d/src/particles.F90
@@ -938,9 +938,9 @@ CONTAINS
     frac_p = 1.0_num / p
 
     ! Precalculate repeated terms
-    pcos_theta = p * cos_theta
     sin_theta = SQRT(1.0_num - cos_theta**2)
-    psin_theta = p*sin_theta
+    pcos_theta = p * cos_theta
+    psin_theta = p * sin_theta
     uz = part%part_p(3) * frac_p
 
     IF (ABS(1.0_num - uz) < 1.0e-10_num) THEN
@@ -952,10 +952,10 @@ CONTAINS
       ! Precalculate repeated terms
       ux = part%part_p(1) * frac_p
       uy = part%part_p(2) * frac_p
-      pfrac_uz = p/SQRT(1.0_num - uz**2)
+      pfrac_uz = p / SQRT(1.0_num - uz**2)
       cos_phi = COS(phi)
-      term_1 = sin_theta*cos_phi*uz*pfrac_uz + pcos_theta
-      term_2 = sin_theta*SIN(phi)*pfrac_uz
+      term_1 = sin_theta * cos_phi * uz * pfrac_uz + pcos_theta
+      term_2 = sin_theta * SIN(phi) * pfrac_uz
 
       part%part_p(1) = ux * term_1 - uy * term_2
       part%part_p(2) = uy * term_1 + ux * term_2

--- a/epoch3d/src/particles.F90
+++ b/epoch3d/src/particles.F90
@@ -910,4 +910,59 @@ CONTAINS
   END SUBROUTINE push_photons
 #endif
 
+
+
+  SUBROUTINE rotate_p(part, cos_theta, phi, part_p)
+
+    ! Let the polar axis be defined as the initial momentum direction of the
+    ! particle, part. This subroutine rotates that momentum direction by the
+    ! polar angle theta (we read in cos(theta)), and the azimuthal angle phi,
+    ! without changing the magnitude.
+    !
+    ! If we have already calculated the magnitude of the particle's momentum,
+    ! part_p, this can also be fed into the subroutine to speed up the
+    ! calculation
+
+    TYPE(particle), POINTER :: part
+    REAL(num), INTENT(IN) :: cos_theta, phi
+    REAL(num), OPTIONAL :: part_p
+    REAL(num) :: p, frac_p, pcos_theta, sin_theta, psin_theta
+    REAL(num) :: ux, uy, uz, pfrac_uz, cos_phi, term_1, term_2
+
+    ! Extract particle momentum
+    IF (PRESENT(part_p)) THEN
+      p = part_p
+    ELSE
+      p = SQRT(part%part_p(1)**2 + part%part_p(2)**2 + part%part_p(3)**2)
+    END IF
+    frac_p = 1.0_num / p
+
+    ! Precalculate repeated terms
+    pcos_theta = p * cos_theta
+    sin_theta = SQRT(1.0_num - cos_theta**2)
+    psin_theta = p*sin_theta
+    uz = part%part_p(3) * frac_p
+
+    IF (ABS(1.0_num - uz) < 1.0e-10_num) THEN
+      ! Special case if the polar direction points along z
+      part%part_p(1) = psin_theta * COS(phi)
+      part%part_p(2) = psin_theta * SIN(phi)
+      part%part_p(3) = pcos_theta * SIGN(1.0_num, uz)
+    ELSE
+      ! Precalculate repeated terms
+      ux = part%part_p(1) * frac_p
+      uy = part%part_p(2) * frac_p
+      pfrac_uz = p/SQRT(1.0_num - uz**2)
+      cos_phi = COS(phi)
+      term_1 = sin_theta*cos_phi*uz*pfrac_uz + pcos_theta
+      term_2 = sin_theta*SIN(phi)*pfrac_uz
+
+      part%part_p(1) = ux * term_1 - uy * term_2
+      part%part_p(2) = uy * term_1 + ux * term_2
+      part%part_p(3) = uz * pcos_theta &
+          + cos_phi * sin_theta * (uz**2 - 1.0_num) * pfrac_uz
+    END IF
+
+  END SUBROUTINE rotate_p
+
 END MODULE particles

--- a/epoch3d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch3d/src/physics_packages/bremsstrahlung.F90
@@ -660,8 +660,10 @@ CONTAINS
     INTEGER, INTENT(IN) :: iphoton, z
     INTEGER :: brem_index
     REAL(num) :: dir_x, dir_y, dir_z, mag_p
-    REAL(num) :: rand_temp, photon_energy, part_e
+    REAL(num) :: rand_temp, photon_energy, photon_p, part_e
+    REAL(num) :: scatter_theta, scatter_phi
     TYPE(particle), POINTER :: new_photon
+    LOGICAL :: add_photon
 
     ! Obtain electron direction (magnitude must be > 0 to prevent 1/0 issues)
     part_e = electron%particle_energy
@@ -679,39 +681,100 @@ CONTAINS
         brem_array(brem_index)%e_table, brem_array(brem_index)%k_table, &
         brem_array(brem_index)%cdf_table, brem_array(brem_index)%state)
 
-    ! Calculate electron recoil
+    ! Is this photon to be added into the simulation?
+    add_photon = (photon_energy > photon_energy_min_bremsstrahlung &
+        .AND. produce_bremsstrahlung_photons)
+
+    ! Ensure photon_energy is a number we can handle at our precision
+    IF (photon_energy < c_tiny) photon_energy = c_tiny
+
+    ! Temporarily store photon momentum in the "new_photon" particle
+    CALL create_particle(new_photon)
+    photon_p = photon_energy / c
+    new_photon%part_p(1) = dir_x * photon_p
+    new_photon%part_p(2) = dir_y * photon_p
+    new_photon%part_p(3) = dir_z * photon_p
+
+    ! Rotate photon according to bremsstrahlung emission angular distribution
+    ! Only consider trajectory changes from e- with high enough energy to be
+    ! added into the simulation
+    IF (use_brem_scatter .AND. add_photon) THEN
+      scatter_theta = calc_scatter_theta(part_e)
+      scatter_phi = 2.0_num*pi*random()
+      CALL rotate_p(new_photon, COS(scatter_theta), scatter_phi, photon_p)
+    END IF
+
+    ! Calculate electron recoil (subtract weighted photon momentum)
     IF (use_bremsstrahlung_recoil) THEN
-      mag_p = mag_p - photon_weight * photon_energy / c
-      electron%part_p(1) = dir_x * mag_p
-      electron%part_p(2) = dir_y * mag_p
-      electron%part_p(3) = dir_z * mag_p
-      electron%particle_energy = electron%particle_energy - photon_energy
+      electron%part_p = electron%part_p - photon_weight*new_photon%part_p
+      electron%particle_energy = electron%particle_energy &
+          - (photon_weight*photon_energy)
     END IF
 
     ! This will only create photons that have energies above a user specified
     ! cutoff and if photon generation is turned on.
-    IF (photon_energy > photon_energy_min_bremsstrahlung &
-        .AND. produce_bremsstrahlung_photons) THEN
-      ! Ensure photon_energy is a number we can handle at our precision
-      IF (photon_energy < c_tiny) photon_energy = c_tiny
-
-      ! Create new photon at the electron position, in the electron direction
-      CALL create_particle(new_photon)
+    IF (add_photon) THEN
+      ! Create new photon at the electron position,
       new_photon%part_pos = electron%part_pos
-      new_photon%part_p(1) = dir_x * photon_energy / c
-      new_photon%part_p(2) = dir_y * photon_energy / c
-      new_photon%part_p(3) = dir_z * photon_energy / c
+
 #ifdef PHOTONS
       new_photon%optical_depth = reset_optical_depth()
 #endif
       new_photon%particle_energy = photon_energy
       new_photon%weight = electron%weight * photon_weight
 
+      ! Add photon to its species
       CALL add_particle_to_partlist(species_list(iphoton)%attached_list, &
           new_photon)
+    ELSE
+      ! We are not adding the photon to the simulation
+      CALL destroy_particle(new_photon)
     END IF
 
   END SUBROUTINE generate_photon
+
+
+
+  ! Calculates the angular scatter of photons using the Tsai method outlined in
+  ! the Geant4 physics reference manual, section 10.2.1. This model is accurate
+  ! for electron energies over 500 keV (as discussed in the "Comparisons
+  ! between Tsai, 2BS and 2BN generators" section)
+
+  FUNCTION calc_scatter_theta(part_E)
+
+    REAL(num), INTENT(IN) :: part_E
+    REAL(num) :: calc_scatter_theta
+    REAL(num) :: gamma_theta_max, gamma_theta, gamma
+    REAL(num) :: a1 = 0.625_num
+    REAL(num) :: a2 = 1.875_num
+    REAL(num) :: border = 0.25_num
+    REAL(num) :: r1, r2, r3
+
+    gamma = part_E/(mc2)
+    gamma_theta_max = pi*gamma
+
+    ! Perform the Tsai algorithm
+    DO
+      ! We require three random numbers per sample attempt
+      r1 = random()
+      r2 = random()
+      r3 = random()
+
+      ! Random sampling returns a u value, which is equivalent to the product of
+      ! the particle gamma factor and the deflection theta
+      IF (r1 < border) THEN
+        gamma_theta = -LOG(r2*r3)/a1
+      ELSE
+        gamma_theta = -LOG(r2*r3)/a2
+      END IF
+
+      ! We require a theta value less than pi
+      IF (gamma_theta <= gamma_theta_max) EXIT
+    END DO
+
+    calc_scatter_theta = gamma_theta/gamma
+
+  END FUNCTION calc_scatter_theta
 
 
 

--- a/epoch3d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch3d/src/physics_packages/bremsstrahlung.F90
@@ -701,15 +701,15 @@ CONTAINS
     ! added into the simulation
     IF (use_brem_scatter .AND. add_photon) THEN
       scatter_theta = calc_scatter_theta(part_e)
-      scatter_phi = 2.0_num*pi*random()
+      scatter_phi = 2.0_num * pi * random()
       CALL rotate_p(new_photon, COS(scatter_theta), scatter_phi, photon_p)
     END IF
 
     ! Calculate electron recoil (subtract weighted photon momentum)
     IF (use_bremsstrahlung_recoil) THEN
-      electron%part_p = electron%part_p - photon_weight*new_photon%part_p
+      electron%part_p = electron%part_p - photon_weight * new_photon%part_p
       electron%particle_energy = electron%particle_energy &
-          - (photon_weight*photon_energy)
+          - photon_weight * photon_energy
     END IF
 
     ! This will only create photons that have energies above a user specified
@@ -745,14 +745,14 @@ CONTAINS
 
     REAL(num), INTENT(IN) :: part_E
     REAL(num) :: calc_scatter_theta
-    REAL(num) :: gamma_theta_max, gamma_theta, gamma
+    REAL(num) :: gamma_theta_max, gamma_theta, gamma_rel
     REAL(num) :: a1 = 0.625_num
     REAL(num) :: a2 = 1.875_num
     REAL(num) :: border = 0.25_num
     REAL(num) :: r1, r2, r3
 
-    gamma = part_E/(m0c2)
-    gamma_theta_max = pi*gamma
+    gamma_rel = part_E / m0c2
+    gamma_theta_max = pi * gamma_rel
 
     ! Perform the Tsai algorithm
     DO
@@ -764,16 +764,16 @@ CONTAINS
       ! Random sampling returns a u value, which is equivalent to the product of
       ! the particle gamma factor and the deflection theta
       IF (r1 < border) THEN
-        gamma_theta = -LOG(r2*r3)/a1
+        gamma_theta = -LOG(r2 * r3) / a1
       ELSE
-        gamma_theta = -LOG(r2*r3)/a2
+        gamma_theta = -LOG(r2 * r3) / a2
       END IF
 
       ! We require a theta value less than pi
       IF (gamma_theta <= gamma_theta_max) EXIT
     END DO
 
-    calc_scatter_theta = gamma_theta/gamma
+    calc_scatter_theta = gamma_theta / gamma_rel
 
   END FUNCTION calc_scatter_theta
 

--- a/epoch3d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch3d/src/physics_packages/bremsstrahlung.F90
@@ -17,6 +17,7 @@ MODULE bremsstrahlung
 #ifdef BREMSSTRAHLUNG
 
   USE partlist
+  USE particles
   USE calc_df
   USE setup
 
@@ -736,9 +737,9 @@ CONTAINS
 
 
   ! Calculates the angular scatter of photons using the Tsai method outlined in
-  ! the Geant4 physics reference manual, section 10.2.1. This model is accurate
-  ! for electron energies over 500 keV (as discussed in the "Comparisons
-  ! between Tsai, 2BS and 2BN generators" section)
+  ! the Geant4 physics reference manual (release 10.6, section 10.2.1). This
+  ! model is accurate for electron energies over 500 keV (as discussed in the
+  ! "Comparisons between Tsai, 2BS and 2BN generators" section)
 
   FUNCTION calc_scatter_theta(part_E)
 
@@ -750,7 +751,7 @@ CONTAINS
     REAL(num) :: border = 0.25_num
     REAL(num) :: r1, r2, r3
 
-    gamma = part_E/(mc2)
+    gamma = part_E/(m0c2)
     gamma_theta_max = pi*gamma
 
     ! Perform the Tsai algorithm

--- a/epoch3d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch3d/src/physics_packages/bremsstrahlung.F90
@@ -652,8 +652,13 @@ CONTAINS
 
 
 
-  ! Generates a photon moving in same direction as the electron, calculating
-  ! electron recoil if appropriate
+  ! Generates a photon at the same position as the electron "electron". Emission
+  ! was triggered due to electron interaction with a nucleus of atomic number z,
+  ! and the photon is written to the species with ID iphoton if appropriate.
+  ! Photon energy is sampled from bremsstrahlung tables, and momentum is either
+  ! parallel to the electron momentum (without brem_scatter), or scattered by
+  ! angles drawn from the bremsstrahlung differential cross section (with
+  ! brem_scatter). Electron recoil is applied if requested.
 
   SUBROUTINE generate_photon(electron, z, iphoton)
 

--- a/epoch3d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch3d/src/physics_packages/bremsstrahlung.F90
@@ -752,9 +752,9 @@ CONTAINS
     REAL(num), INTENT(IN) :: part_E
     REAL(num) :: calc_scatter_theta
     REAL(num) :: gamma_theta_max, gamma_theta, gamma_rel
-    REAL(num) :: a1 = 0.625_num
-    REAL(num) :: a2 = 1.875_num
-    REAL(num) :: border = 0.25_num
+    REAL(num), PARAMETER :: a1 = 0.625_num
+    REAL(num), PARAMETER :: a2 = 1.875_num
+    REAL(num), PARAMETER :: border = 0.25_num
     REAL(num) :: r1, r2, r3
 
     gamma_rel = part_E / m0c2

--- a/epoch3d/src/physics_packages/bremsstrahlung.F90
+++ b/epoch3d/src/physics_packages/bremsstrahlung.F90
@@ -699,7 +699,8 @@ CONTAINS
     ! Rotate photon according to bremsstrahlung emission angular distribution
     ! Only consider trajectory changes from e- with high enough energy to be
     ! added into the simulation
-    IF (use_brem_scatter .AND. add_photon) THEN
+    IF (photon_energy > photon_energy_min_bremsstrahlung &
+        .AND. use_brem_scatter) THEN
       scatter_theta = calc_scatter_theta(part_e)
       scatter_phi = 2.0_num * pi * random()
       CALL rotate_p(new_photon, COS(scatter_theta), scatter_phi, photon_p)

--- a/epoch3d/src/shared_data.F90
+++ b/epoch3d/src/shared_data.F90
@@ -647,6 +647,7 @@ MODULE shared_data
   LOGICAL :: produce_bremsstrahlung_photons = .FALSE.
   LOGICAL :: bremsstrahlung_photon_dynamics = .FALSE.
   LOGICAL :: use_plasma_screening = .FALSE.
+  LOGICAL :: use_brem_scatter = .FALSE.
   CHARACTER(LEN=string_length) :: bremsstrahlung_table_location
 #endif
   LOGICAL :: use_bremsstrahlung = .FALSE.


### PR DESCRIPTION
In GitLab by Stuart Morris (@Status-Mirror) on 03 Sep 2020, 15:30  (GitLab merge request GL#373)

Previously bremsstrahlung photons were emitted in the direction of the incident electron momentum, but this is only accurate for ultra-relativistic electrons. We have added the option for photon emission directions to be sampled from the Tsai differential cross section of bremsstrahlung emission, as is done in Geant4. Code is benchmarked against Geant4 runs for 100 MeV electrons in gold targets.

I have attached some more rigorous documentation, and the input decks used for the benchmarking

[brem_scatter_documentation.pdf](../blob/37c47bd3c9805e46ecfa4681221ec19dd3629922/uploads/e6d0d887f30b88758c3f57665a89b721/brem_scatter_documentation.pdf)

1D: [input.deck](../blob/37c47bd3c9805e46ecfa4681221ec19dd3629922/uploads/3e447c6e8e6559f9270a47f7be5f6abc/input.deck)

2D: [input.deck](../blob/37c47bd3c9805e46ecfa4681221ec19dd3629922/uploads/03b10742073122676a9696d10b8d9644/input.deck)

3D: [input.deck](../blob/37c47bd3c9805e46ecfa4681221ec19dd3629922/uploads/dbab9279f0fdd4ebeda2335cf2fe5997/input.deck)

P.S. The "supporting files" I mention in the report have been emailed to the developers due to their size (the raw Geant4 data is quite large).