### PR TITLE
Fix n_zeros for nstep_snapshot>0

### DIFF
--- a/epoch1d/src/deck/deck_io_block.F90
+++ b/epoch1d/src/deck/deck_io_block.F90
@@ -61,7 +61,7 @@ CONTAINS
   SUBROUTINE io_deck_finalise
 
     INTEGER :: i, io, iu, n_zeros_estimate, n_dumps
-    REAL(num) :: dumps
+    REAL(num) :: dumps, dx
 #ifndef NO_IO
     CHARACTER(LEN=c_max_path_length) :: list_filename
 #endif
@@ -137,6 +137,12 @@ CONTAINS
 
           IF (io_block_list(i)%dt_snapshot > 0.0_num) THEN
             dumps = MAX(dumps, t_end / io_block_list(i)%dt_snapshot)
+          END IF
+
+          ! This might fail if Debye length not resolved
+          IF (io_block_list(i)%nstep_snapshot > 0) THEN
+            dx = (x_max - x_min) / nx_global
+            dumps = MAX(dumps, t_end * c / dx / io_block_list(i)%nstep_snapshot)
           END IF
         END DO
 

--- a/epoch2d/src/deck/deck_io_block.F90
+++ b/epoch2d/src/deck/deck_io_block.F90
@@ -61,7 +61,7 @@ CONTAINS
   SUBROUTINE io_deck_finalise
 
     INTEGER :: i, io, iu, n_zeros_estimate, n_dumps
-    REAL(num) :: dumps
+    REAL(num) :: dumps, dx
 #ifndef NO_IO
     CHARACTER(LEN=c_max_path_length) :: list_filename
 #endif
@@ -137,6 +137,13 @@ CONTAINS
 
           IF (io_block_list(i)%dt_snapshot > 0.0_num) THEN
             dumps = MAX(dumps, t_end / io_block_list(i)%dt_snapshot)
+          END IF
+
+          ! This might fail if Debye length not resolved
+          IF (io_block_list(i)%nstep_snapshot > 0) THEN
+            dx = (x_max - x_min) / nx_global
+            dx = MIN(dx, (y_max - y_min) / ny_global)
+            dumps = MAX(dumps, t_end * c / dx / io_block_list(i)%nstep_snapshot)
           END IF
         END DO
 

--- a/epoch3d/src/deck/deck_io_block.F90
+++ b/epoch3d/src/deck/deck_io_block.F90
@@ -61,7 +61,7 @@ CONTAINS
   SUBROUTINE io_deck_finalise
 
     INTEGER :: i, io, iu, n_zeros_estimate, n_dumps
-    REAL(num) :: dumps
+    REAL(num) :: dumps, dx
 #ifndef NO_IO
     CHARACTER(LEN=c_max_path_length) :: list_filename
 #endif
@@ -137,6 +137,14 @@ CONTAINS
 
           IF (io_block_list(i)%dt_snapshot > 0.0_num) THEN
             dumps = MAX(dumps, t_end / io_block_list(i)%dt_snapshot)
+          END IF
+
+          ! This might fail if Debye length not resolved
+          IF (io_block_list(i)%nstep_snapshot > 0) THEN
+            dx = (x_max - x_min) / nx_global
+            dx = MIN(dx, (y_max - y_min) / ny_global)
+            dx = MIN(dx, (z_max - z_min) / nz_global)
+            dumps = MAX(dumps, t_end * c / dx / io_block_list(i)%nstep_snapshot)
           END IF
         END DO
 


### PR DESCRIPTION
If using `nstep_snapshot` to set the output collision frequency, the number of digits used in the SDF filename isn't set properly. Note the fix only estimates the timestep based on `c`, not the plasma frequency, so if running with a plasma_frequency > 10 * c /dx, this method will fail.