### PR TITLE
Don't try and load background species during window move.

### DIFF
--- a/epoch1d/src/housekeeping/window.F90
+++ b/epoch1d/src/housekeeping/window.F90
@@ -177,6 +177,8 @@ CONTAINS
     DO ispecies = 1, n_species
       species => species_list(ispecies)
 
+      IF (species%background_species) CYCLE
+
       CALL create_empty_partlist(append_list)
       npart_per_cell = FLOOR(species%npart_per_cell, KIND=i8)
       npart_frac = species%npart_per_cell - npart_per_cell

--- a/epoch2d/src/housekeeping/window.F90
+++ b/epoch2d/src/housekeeping/window.F90
@@ -213,6 +213,8 @@ CONTAINS
     DO ispecies = 1, n_species
       species => species_list(ispecies)
 
+      IF (species%background_species) CYCLE
+
       CALL create_empty_partlist(append_list)
       npart_per_cell = FLOOR(species%npart_per_cell, KIND=i8)
       npart_frac = species%npart_per_cell - npart_per_cell

--- a/epoch3d/src/housekeeping/window.F90
+++ b/epoch3d/src/housekeeping/window.F90
@@ -230,6 +230,8 @@ CONTAINS
     DO ispecies = 1, n_species
       species => species_list(ispecies)
 
+      IF (species%background_species) CYCLE
+
       CALL create_empty_partlist(append_list)
       npart_per_cell = FLOOR(species%npart_per_cell, KIND=i8)
       npart_frac = species%npart_per_cell - npart_per_cell


### PR DESCRIPTION
Prevent loading of PIC particles for background species when using the moving window.