### PR TITLE
Initialise release_species_list

### DIFF
--- a/epoch1d/src/deck/deck_species_block.F90
+++ b/epoch1d/src/deck/deck_species_block.F90
@@ -75,6 +75,7 @@ CONTAINS
       ALLOCATE(dumpmask_array(4))
       ALLOCATE(bc_particle_array(2*c_ndims,4))
       release_species = ''
+      release_species_list = ''
     END IF
 
   END SUBROUTINE species_deck_initialise

--- a/epoch2d/src/deck/deck_species_block.F90
+++ b/epoch2d/src/deck/deck_species_block.F90
@@ -75,6 +75,7 @@ CONTAINS
       ALLOCATE(dumpmask_array(4))
       ALLOCATE(bc_particle_array(2*c_ndims,4))
       release_species = ''
+      release_species_list = ''
     END IF
 
   END SUBROUTINE species_deck_initialise

--- a/epoch3d/src/deck/deck_species_block.F90
+++ b/epoch3d/src/deck/deck_species_block.F90
@@ -75,6 +75,7 @@ CONTAINS
       ALLOCATE(dumpmask_array(4))
       ALLOCATE(bc_particle_array(2*c_ndims,4))
       release_species = ''
+      release_species_list = ''
     END IF
 
   END SUBROUTINE species_deck_initialise


### PR DESCRIPTION
Initialise `release_species_list`. Lack of initialisation can result in errors in the `IF (TRIM(release_species(i)) == '')` check.