### PR TITLE
Fix boundary list handling

### DIFF
--- a/epoch1d/src/boundary.F90
+++ b/epoch1d/src/boundary.F90
@@ -610,16 +610,18 @@ CONTAINS
       IF (species_list(ispecies)%attached_list%count == 0) CYCLE
 
       bc_species = species_list(ispecies)%bc_particle
-      IF (bc_species(c_bd_x_min) == c_bc_thermal &
+      IF ((bc_species(c_bd_x_min) == c_bc_thermal &
           .OR. bc_field(c_bd_x_min) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_x_min) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_x_min) == c_bc_cpml_outflow) &
+          .AND. x_min_boundary) THEN
         bnd_x_min = x_min_outer
       ELSE
         bnd_x_min = x_min_local
       END IF
-      IF (bc_species(c_bd_x_max) == c_bc_thermal &
+      IF ((bc_species(c_bd_x_max) == c_bc_thermal &
           .OR. bc_field(c_bd_x_max) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_x_max) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_x_max) == c_bc_cpml_outflow) &
+          .AND. x_max_boundary) THEN
         bnd_x_max = x_max_outer
       ELSE
         bnd_x_max = x_max_local

--- a/epoch1d/src/particles.F90
+++ b/epoch1d/src/particles.F90
@@ -177,16 +177,18 @@ CONTAINS
       END IF
 
       bc_species = species_list(ispecies)%bc_particle
-      IF (bc_species(c_bd_x_min) == c_bc_thermal &
+      IF ((bc_species(c_bd_x_min) == c_bc_thermal &
           .OR. bc_field(c_bd_x_min) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_x_min) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_x_min) == c_bc_cpml_outflow) &
+          .AND. x_min_boundary) THEN
         bnd_x_min = x_min_outer
       ELSE
         bnd_x_min = x_min_local
       END IF
-      IF (bc_species(c_bd_x_max) == c_bc_thermal &
+      IF ((bc_species(c_bd_x_max) == c_bc_thermal &
           .OR. bc_field(c_bd_x_max) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_x_max) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_x_max) == c_bc_cpml_outflow) &
+          .AND. x_max_boundary) THEN
         bnd_x_max = x_max_outer
       ELSE
         bnd_x_max = x_max_local

--- a/epoch2d/src/boundary.F90
+++ b/epoch2d/src/boundary.F90
@@ -960,30 +960,34 @@ CONTAINS
       IF (species_list(ispecies)%attached_list%count == 0) CYCLE
 
       bc_species = species_list(ispecies)%bc_particle
-      IF (bc_species(c_bd_x_min) == c_bc_thermal &
+      IF ((bc_species(c_bd_x_min) == c_bc_thermal &
           .OR. bc_field(c_bd_x_min) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_x_min) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_x_min) == c_bc_cpml_outflow) &
+          .AND. x_min_boundary) THEN
         bnd_x_min = x_min_outer
       ELSE
         bnd_x_min = x_min_local
       END IF
-      IF (bc_species(c_bd_x_max) == c_bc_thermal &
+      IF ((bc_species(c_bd_x_max) == c_bc_thermal &
           .OR. bc_field(c_bd_x_max) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_x_max) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_x_max) == c_bc_cpml_outflow) &
+          .AND. x_max_boundary) THEN
         bnd_x_max = x_max_outer
       ELSE
         bnd_x_max = x_max_local
       END IF
-      IF (bc_species(c_bd_y_min) == c_bc_thermal &
+      IF ((bc_species(c_bd_y_min) == c_bc_thermal &
           .OR. bc_field(c_bd_y_min) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_y_min) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_y_min) == c_bc_cpml_outflow) &
+          .AND. y_min_boundary) THEN
         bnd_y_min = y_min_outer
       ELSE
         bnd_y_min = y_min_local
       END IF
-      IF (bc_species(c_bd_y_max) == c_bc_thermal &
+      IF ((bc_species(c_bd_y_max) == c_bc_thermal &
           .OR. bc_field(c_bd_y_max) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_y_max) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_y_max) == c_bc_cpml_outflow) &
+          .AND. y_max_boundary) THEN
         bnd_y_max = y_max_outer
       ELSE
         bnd_y_max = y_max_local

--- a/epoch2d/src/particles.F90
+++ b/epoch2d/src/particles.F90
@@ -186,30 +186,34 @@ CONTAINS
       END IF
 
       bc_species = species_list(ispecies)%bc_particle
-      IF (bc_species(c_bd_x_min) == c_bc_thermal &
+      IF ((bc_species(c_bd_x_min) == c_bc_thermal &
           .OR. bc_field(c_bd_x_min) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_x_min) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_x_min) == c_bc_cpml_outflow) &
+          x_min_boundary) THEN
         bnd_x_min = x_min_outer
       ELSE
         bnd_x_min = x_min_local
       END IF
-      IF (bc_species(c_bd_x_max) == c_bc_thermal &
+      IF ((bc_species(c_bd_x_max) == c_bc_thermal &
           .OR. bc_field(c_bd_x_max) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_x_max) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_x_max) == c_bc_cpml_outflow) &
+          .AND. x_max_boundary) THEN
         bnd_x_max = x_max_outer
       ELSE
         bnd_x_max = x_max_local
       END IF
-      IF (bc_species(c_bd_y_min) == c_bc_thermal &
+      IF ((bc_species(c_bd_y_min) == c_bc_thermal &
           .OR. bc_field(c_bd_y_min) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_y_min) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_y_min) == c_bc_cpml_outflow) &
+          .AND. y_min_boundary) THEN
         bnd_y_min = y_min_outer
       ELSE
         bnd_y_min = y_min_local
       END IF
-      IF (bc_species(c_bd_y_max) == c_bc_thermal &
+      IF ((bc_species(c_bd_y_max) == c_bc_thermal &
           .OR. bc_field(c_bd_y_max) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_y_max) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_y_max) == c_bc_cpml_outflow) &
+          .AND. y_max_boundary) THEN
         bnd_y_max = y_max_outer
       ELSE
         bnd_y_max = y_max_local

--- a/epoch3d/src/boundary.F90
+++ b/epoch3d/src/boundary.F90
@@ -1329,44 +1329,50 @@ CONTAINS
       IF (species_list(ispecies)%attached_list%count == 0) CYCLE
 
       bc_species = species_list(ispecies)%bc_particle
-      IF (bc_species(c_bd_x_min) == c_bc_thermal &
+      IF ((bc_species(c_bd_x_min) == c_bc_thermal &
           .OR. bc_field(c_bd_x_min) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_x_min) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_x_min) == c_bc_cpml_outflow) &
+          .AND. x_min_boundary) THEN
         bnd_x_min = x_min_outer
       ELSE
         bnd_x_min = x_min_local
       END IF
-      IF (bc_species(c_bd_x_max) == c_bc_thermal &
+      IF ((bc_species(c_bd_x_max) == c_bc_thermal &
           .OR. bc_field(c_bd_x_max) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_x_max) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_x_max) == c_bc_cpml_outflow) &
+          .AND. x_max_boundary) THEN
         bnd_x_max = x_max_outer
       ELSE
         bnd_x_max = x_max_local
       END IF
-      IF (bc_species(c_bd_y_min) == c_bc_thermal &
+      IF ((bc_species(c_bd_y_min) == c_bc_thermal &
           .OR. bc_field(c_bd_y_min) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_y_min) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_y_min) == c_bc_cpml_outflow) &
+          .AND. y_min_boundary) THEN
         bnd_y_min = y_min_outer
       ELSE
         bnd_y_min = y_min_local
       END IF
-      IF (bc_species(c_bd_y_max) == c_bc_thermal &
+      IF ((bc_species(c_bd_y_max) == c_bc_thermal &
           .OR. bc_field(c_bd_y_max) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_y_max) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_y_max) == c_bc_cpml_outflow) &
+          .AND. y_max_boundary) THEN
         bnd_y_max = y_max_outer
       ELSE
         bnd_y_max = y_max_local
       END IF
-      IF (bc_species(c_bd_z_min) == c_bc_thermal &
+      IF ((bc_species(c_bd_z_min) == c_bc_thermal &
           .OR. bc_field(c_bd_z_min) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_z_min) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_z_min) == c_bc_cpml_outflow) &
+          .AND. z_min_boundary) THEN
         bnd_z_min = z_min_outer
       ELSE
         bnd_z_min = z_min_local
       END IF
-      IF (bc_species(c_bd_z_max) == c_bc_thermal &
+      IF ((bc_species(c_bd_z_max) == c_bc_thermal &
           .OR. bc_field(c_bd_z_max) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_z_max) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_z_max) == c_bc_cpml_outflow) &
+          .AND.z_max_boundary) THEN
         bnd_z_max = z_max_outer
       ELSE
         bnd_z_max = z_max_local

--- a/epoch3d/src/particles.F90
+++ b/epoch3d/src/particles.F90
@@ -193,44 +193,50 @@ CONTAINS
       END IF
 
       bc_species = species_list(ispecies)%bc_particle
-      IF (bc_species(c_bd_x_min) == c_bc_thermal &
+      IF ((bc_species(c_bd_x_min) == c_bc_thermal &
           .OR. bc_field(c_bd_x_min) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_x_min) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_x_min) == c_bc_cpml_outflow) &
+          x_min_boundary) THEN
         bnd_x_min = x_min_outer
       ELSE
         bnd_x_min = x_min_local
       END IF
-      IF (bc_species(c_bd_x_max) == c_bc_thermal &
+      IF ((bc_species(c_bd_x_max) == c_bc_thermal &
           .OR. bc_field(c_bd_x_max) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_x_max) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_x_max) == c_bc_cpml_outflow) &
+          .AND. x_max_boundary) THEN
         bnd_x_max = x_max_outer
       ELSE
         bnd_x_max = x_max_local
       END IF
-      IF (bc_species(c_bd_y_min) == c_bc_thermal &
+      IF ((bc_species(c_bd_y_min) == c_bc_thermal &
           .OR. bc_field(c_bd_y_min) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_y_min) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_y_min) == c_bc_cpml_outflow) &
+          .AND. y_min_boundary) THEN
         bnd_y_min = y_min_outer
       ELSE
         bnd_y_min = y_min_local
       END IF
-      IF (bc_species(c_bd_y_max) == c_bc_thermal &
+      IF ((bc_species(c_bd_y_max) == c_bc_thermal &
           .OR. bc_field(c_bd_y_max) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_y_max) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_y_max) == c_bc_cpml_outflow) &
+          .AND. y_max_boundary) THEN
         bnd_y_max = y_max_outer
       ELSE
         bnd_y_max = y_max_local
       END IF
-      IF (bc_species(c_bd_z_min) == c_bc_thermal &
+      IF ((bc_species(c_bd_z_min) == c_bc_thermal &
           .OR. bc_field(c_bd_z_min) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_z_min) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_z_min) == c_bc_cpml_outflow) &
+          .AND. z_min_boundary) THEN
         bnd_z_min = z_min_outer
       ELSE
         bnd_z_min = z_min_local
       END IF
-      IF (bc_species(c_bd_z_max) == c_bc_thermal &
+      IF ((bc_species(c_bd_z_max) == c_bc_thermal &
           .OR. bc_field(c_bd_z_max) == c_bc_cpml_laser &
-          .OR. bc_field(c_bd_z_max) == c_bc_cpml_outflow) THEN
+          .OR. bc_field(c_bd_z_max) == c_bc_cpml_outflow) &
+          .AND. z_max_boundary) THEN
         bnd_z_max = z_max_outer
       ELSE
         bnd_z_max = z_max_local


### PR DESCRIPTION
Only adjust `bnd_x_min` and similar variables used for boundary checking on processors corresponding to actual physical boundary. Previously this was done on all processors, which resulted in particles not being transferred between ranks correctly.