### PR TITLE
Time-step dependent force interpolation scheme

### DIFF
--- a/epoch1d/Makefile
+++ b/epoch1d/Makefile
@@ -206,6 +206,9 @@ DEFINES := $(DEFINE)
 # Use fifth order particle weighting (default is third order).
 #DEFINES += $(D)PARTICLE_SHAPE_BSPLINE3
 
+# Use WT scheme for field interpolation
+#DEFINES += $(D)WT_INTERPOLATION
+
 # Include a unique global particle ID. The first flag defines the ID using
 # an 8-byte integer, the second uses 4-bytes.
 #DEFINES += $(D)PARTICLE_ID

--- a/epoch1d/src/constants.F90
+++ b/epoch1d/src/constants.F90
@@ -266,6 +266,7 @@ MODULE constants
   INTEGER(i8), PARAMETER :: c_def_use_isatty = 2**24
   INTEGER(i8), PARAMETER :: c_def_use_mpi3 = 2**25
   INTEGER(i8), PARAMETER :: c_def_bremsstrahlung = 2**26
+  INTEGER(i8), PARAMETER :: c_def_wt_interpolation = 2**27
 
   ! Stagger types
   INTEGER, PARAMETER :: c_stagger_ex = c_stagger_face_x

--- a/epoch1d/src/housekeeping/setup.F90
+++ b/epoch1d/src/housekeeping/setup.F90
@@ -621,6 +621,16 @@ CONTAINS
 
     dt = dt_multiplier * dt
 
+#ifdef WT_INTERPOLATION
+    IF (c * dt / dx > 0.5_num) THEN
+      IF (rank == 0) THEN
+        PRINT*, '*** ERROR ***'
+        PRINT*, 'Cannot use WT beacause c*dt/dx>0.5'
+      END IF
+      CALL abort_code(c_err_bad_setup)
+    END IF
+#endif
+
     IF (.NOT. any_average) RETURN
 
     DO io = 1, n_io_blocks

--- a/epoch1d/src/housekeeping/welcome.F90
+++ b/epoch1d/src/housekeeping/welcome.F90
@@ -99,6 +99,9 @@ CONTAINS
 #ifdef PARTICLE_SHAPE_TOPHAT
     found = .TRUE.
 #endif
+#ifdef WT_INTERPOLATION
+    found = .TRUE.
+#endif
 #ifdef PER_SPECIES_WEIGHT
     found = .TRUE.
 #endif
@@ -185,6 +188,10 @@ CONTAINS
 #ifdef PARTICLE_SHAPE_TOPHAT
     defines = IOR(defines, c_def_particle_shape_tophat)
     WRITE(*,*) 'Top-hat particle shape -DPARTICLE_SHAPE_TOPHAT'
+#endif
+#ifdef WT_INTERPOLATION
+    defines = IOR(defines, c_def_wt_interpolation)
+    WRITE(*,*) 'WT interpolation scheme -DWT_INTERPOLATION'
 #endif
 #ifdef PER_SPECIES_WEIGHT
     defines = IOR(defines, c_def_per_particle_weight)

--- a/epoch1d/src/include/bspline3/gx_wt.inc
+++ b/epoch1d/src/include/bspline3/gx_wt.inc
@@ -1,0 +1,15 @@
+! IMPORTANT NOTE
+! These weight need to be multiplied by 1/24
+        wt_var1 = wt_facx * (wt_dtx + cell_frac_x)**4
+        wt_var2 = wt_facx * (wt_dtx - cell_frac_x)**4
+        wt_var3 = SIGN(wt_var1, wt_dtx + cell_frac_x) &
+            + SIGN(wt_var2, wt_dtx - cell_frac_x)
+        wt_var4 = ((3.0_num - cell_frac_x) * cell_frac_x + 3.0_num - wt_dtx2) &
+            * cell_frac_x + 1.0_num + wt_dtx2
+        wt_var5 = ((3.0_num + cell_frac_x) * cell_frac_x - 3.0_num + wt_dtx2) &
+            * cell_frac_x + 1.0_num + wt_dtx2
+        gx(-2) = wt_var3 + wt_var1 - wt_var2
+        gx(-1) = 4.0_num * (wt_var4 - wt_var3)
+        gx( 0) = 24.0_num + 6.0_num * wt_var3 - 4.0_num * (wt_var4 + wt_var5)
+        gx( 1) = 4.0_num * (wt_var5 - wt_var3)
+        gx( 2) = wt_var3 + wt_var2 - wt_var1

--- a/epoch1d/src/include/tophat/gx_wt.inc
+++ b/epoch1d/src/include/tophat/gx_wt.inc
@@ -1,0 +1,4 @@
+        wt_var1 = wt_facx * (ABS(wt_dtx + cell_frac_x) &
+            - ABS(wt_dtx - cell_frac_x))
+        gx( 0) = 0.5_num + wt_var1
+        gx( 1) = 0.5_num - wt_var1

--- a/epoch1d/src/include/triangle/gx_wt.inc
+++ b/epoch1d/src/include/triangle/gx_wt.inc
@@ -1,0 +1,8 @@
+! IMPORTANT NOTE
+! These weight need to be multiplied by 1/2
+        wt_var1 = wt_facx * ( &
+            ABS(wt_dtx + cell_frac_x) * (wt_dtx + cell_frac_x) &
+            + ABS(wt_dtx - cell_frac_x) * (wt_dtx - cell_frac_x))
+        gx(-1) = wt_var1 + cell_frac_x
+        gx( 0) = 2.0_num - 2.0_num * wt_var1
+        gx( 1) = wt_var1 - cell_frac_x

--- a/epoch1d/src/particles.F90
+++ b/epoch1d/src/particles.F90
@@ -299,6 +299,7 @@ CONTAINS
 
         ! For WT scheme, use hx0 to store the weight factors used to weigh
         ! particle properties onto grid at Xi0*. And calculate gx for WT.
+        ! Y. Lu et al., J. Comput. Phys 413, 109388 (2020)
         ! NOTE: These weights require an additional multiplication factor!
 #ifdef WT_INTERPOLATION
         hx0 = gx

--- a/epoch1d/src/particles.F90
+++ b/epoch1d/src/particles.F90
@@ -82,6 +82,14 @@ CONTAINS
     ! This is to deal with the grid stagger
     REAL(num), DIMENSION(sf_min-1:sf_max+1) :: hx
 
+    ! For WT scheme, the weight factors used to weight particle properties onto
+    ! grid to calculate J is same as bspline3, triangle or tophat.  But the
+    ! particle weight factors to weight fields onto particles are not bspline3,
+    ! triangle or tophat. We use hx0 to store the former weight factors at Xi0*.
+#ifdef WT_INTERPOLATION
+    REAL(num), DIMENSION(sf_min-1:sf_max+1) :: hx0
+#endif
+
     ! Fields at particle location
     REAL(num) :: ex_part, ey_part, ez_part, bx_part, by_part, bz_part
 
@@ -126,6 +134,15 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_facx
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 #ifdef DELTAF_METHOD
     REAL(num) :: weight_back
 #endif
@@ -141,6 +158,9 @@ CONTAINS
     jz = 0.0_num
 
     gx = 0.0_num
+#ifdef WT_INTERPOLATION
+    hx0 = 0.0_num
+#endif
 
     ! Unvarying multiplication factors
 
@@ -152,6 +172,14 @@ CONTAINS
 
     idtf = idt * fac
     idxf = idx * fac
+
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_facx = 0.25_num / wt_dtx
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+#endif
+#endif
 
     DO ispecies = 1, n_species
       current => species_list(ispecies)%attached_list%head
@@ -267,6 +295,20 @@ CONTAINS
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+
+        ! For WT scheme, use hx0 to store the weight factors used to weigh
+        ! particle properties onto grid at Xi0*. And calculate gx for WT.
+        ! NOTE: These weights require an additional multiplication factor!
+#ifdef WT_INTERPOLATION
+        hx0 = gx
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
         ! Now redo shifted by half a cell due to grid stagger.
@@ -431,6 +473,9 @@ CONTAINS
 
           ! Now change Xi1* to be Xi1*-Xi0*. This makes the representation of
           ! the current update much simpler
+#ifdef WT_INTERPOLATION
+          gx = hx0
+#endif
           hx = hx - gx
 
           ! Remember that due to CFL condition particle can never cross more

--- a/epoch1d/src/physics_packages/ionise.F90
+++ b/epoch1d/src/physics_packages/ionise.F90
@@ -375,10 +375,27 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_facx
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 
     idx = 1.0_num / dx
 
     dfac = fac**2 / dt / dx
+
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_facx = 0.25_num / wt_dtx
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+#endif
+#endif
 
     ! Stores ionised species until close of ionisation run. Main purpose of this
     ! method is to ensure proper statistics (i.e. prevent ionisation rate being
@@ -420,6 +437,7 @@ CONTAINS
         ! Also used to weight particle properties onto grid, used later
         ! to calculate J
         ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/gx.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
@@ -427,6 +445,16 @@ CONTAINS
 #else
 #include "triangle/gx.inc"
 #endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
+#endif
+
 
         ! Now redo shifted by half a cell due to grid stagger.
         ! Use shifted version for ex in X, ey in Y, ez in Z
@@ -636,10 +664,27 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_facx
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 
     idx = 1.0_num / dx
 
     dfac = fac**2 / dt / dx
+
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_facx = 0.25_num / wt_dtx
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+#endif
+#endif
 
     ! Stores ionised species until close of ionisation run. Main purpose of this
     ! method is to ensure proper statistics (i.e. prevent ionisation rate being
@@ -681,12 +726,22 @@ CONTAINS
         ! Also used to weight particle properties onto grid, used later
         ! to calculate J
         ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/gx.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
         ! Now redo shifted by half a cell due to grid stagger.
@@ -883,10 +938,27 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_facx
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 
     idx = 1.0_num / dx
 
     dfac = fac**2 / dt / dx
+
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_facx = 0.25_num / wt_dtx
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+#endif
+#endif
 
     ! Stores ionised species until close of ionisation run. Main purpose of this
     ! method is to ensure proper statistics (i.e. prevent ionisation rate being
@@ -928,12 +1000,22 @@ CONTAINS
         ! Also used to weight particle properties onto grid, used later
         ! to calculate J
         ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/gx.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
         ! Now redo shifted by half a cell due to grid stagger.
@@ -1120,10 +1202,27 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_facx
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 
     idx = 1.0_num / dx
 
     dfac = fac**2 / dt / dx
+
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_facx = 0.25_num / wt_dtx
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+#endif
+#endif
 
     ! Stores ionised species until close of ionisation run. Main purpose of this
     ! method is to ensure proper statistics (i.e. prevent ionisation rate being
@@ -1165,12 +1264,22 @@ CONTAINS
         ! Also used to weight particle properties onto grid, used later
         ! to calculate J
         ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/gx.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
         ! Now redo shifted by half a cell due to grid stagger.

--- a/epoch1d/src/physics_packages/photons.F90
+++ b/epoch1d/src/physics_packages/photons.F90
@@ -779,6 +779,24 @@ CONTAINS
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
 
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_facx
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
+
+    ! Unvarying factors for WT scheme
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_facx = 0.25_num / wt_dtx
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+#endif
+#endif
     ! Grid cell position as a fraction.
 #ifdef PARTICLE_SHAPE_TOPHAT
     cell_x_r = part_x / dx - 0.5_num
@@ -796,12 +814,22 @@ CONTAINS
     ! Also used to weight particle properties onto grid, used later
     ! to calculate J
     ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/gx.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
     ! Now redo shifted by half a cell due to grid stagger.

--- a/epoch2d/Makefile
+++ b/epoch2d/Makefile
@@ -206,6 +206,9 @@ DEFINES := $(DEFINE)
 # Use fifth order particle weighting (default is third order).
 #DEFINES += $(D)PARTICLE_SHAPE_BSPLINE3
 
+# Use WT scheme for field interpolation
+#DEFINES += $(D)WT_INTERPOLATION
+
 # Include a unique global particle ID. The first flag defines the ID using
 # an 8-byte integer, the second uses 4-bytes.
 #DEFINES += $(D)PARTICLE_ID

--- a/epoch2d/src/constants.F90
+++ b/epoch2d/src/constants.F90
@@ -266,6 +266,7 @@ MODULE constants
   INTEGER(i8), PARAMETER :: c_def_use_isatty = 2**24
   INTEGER(i8), PARAMETER :: c_def_use_mpi3 = 2**25
   INTEGER(i8), PARAMETER :: c_def_bremsstrahlung = 2**26
+  INTEGER(i8), PARAMETER :: c_def_wt_interpolation = 2**27
 
   ! Stagger types
   INTEGER, PARAMETER :: c_stagger_ex = c_stagger_face_x

--- a/epoch2d/src/housekeeping/setup.F90
+++ b/epoch2d/src/housekeeping/setup.F90
@@ -690,6 +690,16 @@ CONTAINS
 
     dt = dt_multiplier * dt
 
+#ifdef WT_INTERPOLATION
+    IF (c * dt / MIN(dx, dy) > 0.5_num) THEN
+      IF (rank == 0) THEN
+        PRINT*, '*** ERROR ***'
+        PRINT*, 'Cannot use WT beacause c*dt/min(dx,dy)>0.5'
+      END IF
+      CALL abort_code(c_err_bad_setup)
+    END IF
+#endif
+
     IF (.NOT. any_average) RETURN
 
     DO io = 1, n_io_blocks

--- a/epoch2d/src/housekeeping/welcome.F90
+++ b/epoch2d/src/housekeeping/welcome.F90
@@ -99,6 +99,9 @@ CONTAINS
 #ifdef PARTICLE_SHAPE_TOPHAT
     found = .TRUE.
 #endif
+#ifdef WT_INTERPOLATION
+    found = .TRUE.
+#endif
 #ifdef PER_SPECIES_WEIGHT
     found = .TRUE.
 #endif
@@ -185,6 +188,10 @@ CONTAINS
 #ifdef PARTICLE_SHAPE_TOPHAT
     defines = IOR(defines, c_def_particle_shape_tophat)
     WRITE(*,*) 'Top-hat particle shape -DPARTICLE_SHAPE_TOPHAT'
+#endif
+#ifdef WT_INTERPOLATION
+    defines = IOR(defines, c_def_wt_interpolation)
+    WRITE(*,*) 'WT interpolation scheme -DWT_INTERPOLATION'
 #endif
 #ifdef PER_SPECIES_WEIGHT
     defines = IOR(defines, c_def_per_particle_weight)

--- a/epoch2d/src/include/bspline3/gx_wt.inc
+++ b/epoch2d/src/include/bspline3/gx_wt.inc
@@ -1,0 +1,29 @@
+! IMPORTANT NOTE
+! These weight need to be multiplied by 1/24
+        wt_var1 = wt_facx * (wt_dtx + cell_frac_x)**4
+        wt_var2 = wt_facx * (wt_dtx - cell_frac_x)**4
+        wt_var3 = SIGN(wt_var1, wt_dtx + cell_frac_x) &
+            + SIGN(wt_var2, wt_dtx - cell_frac_x)
+        wt_var4 = ((3.0_num - cell_frac_x) * cell_frac_x + 3.0_num - wt_dtx2) &
+            * cell_frac_x + 1.0_num + wt_dtx2
+        wt_var5 = ((3.0_num + cell_frac_x) * cell_frac_x - 3.0_num + wt_dtx2) &
+            * cell_frac_x + 1.0_num + wt_dtx2
+        gx(-2) = wt_var3 + wt_var1 - wt_var2
+        gx(-1) = 4.0_num * (wt_var4 - wt_var3)
+        gx( 0) = 24.0_num + 6.0_num * wt_var3 - 4.0_num * (wt_var4 + wt_var5)
+        gx( 1) = 4.0_num * (wt_var5 - wt_var3)
+        gx( 2) = wt_var3 + wt_var2 - wt_var1
+
+        wt_var1 = wt_facy * (wt_dty + cell_frac_y)**4
+        wt_var2 = wt_facy * (wt_dty - cell_frac_y)**4
+        wt_var3 = SIGN(wt_var1, wt_dty + cell_frac_y) &
+            + SIGN(wt_var2, wt_dty - cell_frac_y)
+        wt_var4 = ((3.0_num - cell_frac_y) * cell_frac_y + 3.0_num - wt_dty2) &
+            * cell_frac_y + 1.0_num + wt_dty2
+        wt_var5 = ((3.0_num + cell_frac_y) * cell_frac_y - 3.0_num + wt_dty2) &
+            * cell_frac_y + 1.0_num + wt_dty2
+        gy(-2) = wt_var3 + wt_var1 - wt_var2
+        gy(-1) = 4.0_num * (wt_var4 - wt_var3)
+        gy( 0) = 24.0_num + 6.0_num * wt_var3 - 4.0_num * (wt_var4 + wt_var5)
+        gy( 1) = 4.0_num * (wt_var5 - wt_var3)
+        gy( 2) = wt_var3 + wt_var2 - wt_var1

--- a/epoch2d/src/include/tophat/gx_wt.inc
+++ b/epoch2d/src/include/tophat/gx_wt.inc
@@ -1,0 +1,9 @@
+        wt_var1 = wt_facx * (ABS(wt_dtx + cell_frac_x) &
+            - ABS(wt_dtx - cell_frac_x))
+        gx( 0) = 0.5_num + wt_var1
+        gx( 1) = 0.5_num - wt_var1
+
+        wt_var1 = wt_facy * (ABS(wt_dty + cell_frac_y) &
+            - ABS(wt_dty - cell_frac_y))
+        gy( 0) = 0.5_num + wt_var1
+        gy( 1) = 0.5_num - wt_var1

--- a/epoch2d/src/include/triangle/gx_wt.inc
+++ b/epoch2d/src/include/triangle/gx_wt.inc
@@ -1,0 +1,15 @@
+! IMPORTANT NOTE
+! These weight need to be multiplied by 1/2
+        wt_var1 = wt_facx * ( &
+            ABS(wt_dtx + cell_frac_x) * (wt_dtx + cell_frac_x) &
+            + ABS(wt_dtx - cell_frac_x) * (wt_dtx - cell_frac_x))
+        gx(-1) = wt_var1 + cell_frac_x
+        gx( 0) = 2.0_num - 2.0_num * wt_var1
+        gx( 1) = wt_var1 - cell_frac_x
+
+        wt_var1 = wt_facy * ( &
+            ABS(wt_dty + cell_frac_y) * (wt_dty + cell_frac_y) &
+            + ABS(wt_dty - cell_frac_y) * (wt_dty - cell_frac_y))
+        gy(-1) = wt_var1 + cell_frac_y
+        gy( 0) = 2.0_num - 2.0_num * wt_var1
+        gy( 1) = wt_var1 - cell_frac_y

--- a/epoch2d/src/particles.F90
+++ b/epoch2d/src/particles.F90
@@ -322,6 +322,7 @@ CONTAINS
 
         ! For WT scheme, use hx0 to store the weight factors used to weigh
         ! particle properties onto grid at Xi0*. And calculate gx for WT.
+        ! Y. Lu et al., J. Comput. Phys 413, 109388 (2020)
         ! NOTE: These weights require an additional multiplication factor!
 #ifdef WT_INTERPOLATION
         hx0 = gx

--- a/epoch2d/src/particles.F90
+++ b/epoch2d/src/particles.F90
@@ -85,6 +85,14 @@ CONTAINS
     ! This is to deal with the grid stagger
     REAL(num), DIMENSION(sf_min-1:sf_max+1) :: hx, hy
 
+    ! For WT scheme, the weight factors used to weight particle properties onto
+    ! grid to calculate J is same as bspline3, triangle or tophat.  But the
+    ! particle weight factors to weight fields onto particles are not bspline3,
+    ! triangle or tophat. We use hx0 to store the former weight factors at Xi0*.
+#ifdef WT_INTERPOLATION
+    REAL(num), DIMENSION(sf_min-1:sf_max+1) :: hx0, hy0
+#endif
+
     ! Fields at particle location
     REAL(num) :: ex_part, ey_part, ez_part, bx_part, by_part, bz_part
 
@@ -130,6 +138,15 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_dty, wt_facx, wt_facy
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2, wt_dty2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 #ifdef DELTAF_METHOD
     REAL(num) :: weight_back
 #endif
@@ -146,6 +163,10 @@ CONTAINS
 
     gx = 0.0_num
     gy = 0.0_num
+#ifdef WT_INTERPOLATION
+    hx0 = 0.0_num
+    hy0 = 0.0_num
+#endif
 
     ! Unvarying multiplication factors
 
@@ -160,6 +181,17 @@ CONTAINS
     idty = idt * idy * fac
     idtx = idt * idx * fac
     idxy = idx * idy * fac
+
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_dty = c * dt / dy
+    wt_facx = 0.25_num / wt_dtx
+    wt_facy = 0.25_num / wt_dty
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+    wt_dty2 = wt_dty**2
+#endif
+#endif
 
     DO ispecies = 1, n_species
       current => species_list(ispecies)%attached_list%head
@@ -286,6 +318,21 @@ CONTAINS
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+
+        ! For WT scheme, use hx0 to store the weight factors used to weigh
+        ! particle properties onto grid at Xi0*. And calculate gx for WT.
+        ! NOTE: These weights require an additional multiplication factor!
+#ifdef WT_INTERPOLATION
+        hx0 = gx
+        hy0 = gy
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
         ! Now redo shifted by half a cell due to grid stagger.
@@ -469,6 +516,10 @@ CONTAINS
 
           ! Now change Xi1* to be Xi1*-Xi0*. This makes the representation of
           ! the current update much simpler
+#ifdef WT_INTERPOLATION
+          gx = hx0
+          gy = hy0
+#endif
           hx = hx - gx
           hy = hy - gy
 

--- a/epoch2d/src/physics_packages/ionise.F90
+++ b/epoch2d/src/physics_packages/ionise.F90
@@ -412,11 +412,31 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_dty, wt_facx, wt_facy
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2, wt_dty2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 
     idx = 1.0_num / dx
     idy = 1.0_num / dy
 
     dfac = fac**2 / dt / dx / dy
+
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_dty = c * dt / dy
+    wt_facx = 0.25_num / wt_dtx
+    wt_facy = 0.25_num / wt_dty
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+    wt_dty2 = wt_dty**2
+#endif
+#endif
 
     ! Stores ionised species until close of ionisation run. Main purpose of this
     ! method is to ensure proper statistics (i.e. prevent ionisation rate being
@@ -465,12 +485,22 @@ CONTAINS
         ! Also used to weight particle properties onto grid, used later
         ! to calculate J
         ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/gx.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
         ! Now redo shifted by half a cell due to grid stagger.
@@ -694,11 +724,31 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_dty, wt_facx, wt_facy
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2, wt_dty2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 
     idx = 1.0_num / dx
     idy = 1.0_num / dy
 
     dfac = fac**2 / dt / dx / dy
+
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_dty = c * dt / dy
+    wt_facx = 0.25_num / wt_dtx
+    wt_facy = 0.25_num / wt_dty
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+    wt_dty2 = wt_dty**2
+#endif
+#endif
 
     ! Stores ionised species until close of ionisation run. Main purpose of this
     ! method is to ensure proper statistics (i.e. prevent ionisation rate being
@@ -747,12 +797,22 @@ CONTAINS
         ! Also used to weight particle properties onto grid, used later
         ! to calculate J
         ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/gx.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
         ! Now redo shifted by half a cell due to grid stagger.
@@ -962,11 +1022,31 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_dty, wt_facx, wt_facy
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2, wt_dty2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 
     idx = 1.0_num / dx
     idy = 1.0_num / dy
 
     dfac = fac**2 / dt / dx / dy
+
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_dty = c * dt / dy
+    wt_facx = 0.25_num / wt_dtx
+    wt_facy = 0.25_num / wt_dty
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+    wt_dty2 = wt_dty**2
+#endif
+#endif
 
     ! Stores ionised species until close of ionisation run. Main purpose of this
     ! method is to ensure proper statistics (i.e. prevent ionisation rate being
@@ -1037,12 +1117,22 @@ CONTAINS
         dcellx = 0
         dcelly = 0
         ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/hx_dcell.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
 #include "tophat/hx_dcell.inc"
 #else
 #include "triangle/hx_dcell.inc"
+#endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
         ! These are the electric and magnetic fields interpolated to the
@@ -1220,11 +1310,31 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_dty, wt_facx, wt_facy
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2, wt_dty2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 
     idx = 1.0_num / dx
     idy = 1.0_num / dy
 
     dfac = fac**2 / dt / dx / dy
+
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_dty = c * dt / dy
+    wt_facx = 0.25_num / wt_dtx
+    wt_facy = 0.25_num / wt_dty
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+    wt_dty2 = wt_dty**2
+#endif
+#endif
 
     ! Stores ionised species until close of ionisation run. Main purpose of this
     ! method is to ensure proper statistics (i.e. prevent ionisation rate being
@@ -1273,12 +1383,22 @@ CONTAINS
         ! Also used to weight particle properties onto grid, used later
         ! to calculate J
         ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/gx.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
         ! Now redo shifted by half a cell due to grid stagger.

--- a/epoch2d/src/physics_packages/photons.F90
+++ b/epoch2d/src/physics_packages/photons.F90
@@ -780,6 +780,27 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_dty, wt_facx, wt_facy
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2, wt_dty2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
+
+    ! Unvarying factors for WT scheme
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_dty = c * dt / dy
+    wt_facx = 0.25_num / wt_dtx
+    wt_facy = 0.25_num / wt_dty
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+    wt_dty2 = wt_dty**2
+#endif
+#endif
 
     ! Grid cell position as a fraction.
 #ifdef PARTICLE_SHAPE_TOPHAT
@@ -804,12 +825,22 @@ CONTAINS
     ! Also used to weight particle properties onto grid, used later
     ! to calculate J
     ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/gx.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
     ! Now redo shifted by half a cell due to grid stagger.

--- a/epoch3d/Makefile
+++ b/epoch3d/Makefile
@@ -206,6 +206,9 @@ DEFINES := $(DEFINE)
 # Use fifth order particle weighting (default is third order).
 #DEFINES += $(D)PARTICLE_SHAPE_BSPLINE3
 
+# Use WT scheme for field interpolation
+#DEFINES += $(D)WT_INTERPOLATION
+
 # Include a unique global particle ID. The first flag defines the ID using
 # an 8-byte integer, the second uses 4-bytes.
 #DEFINES += $(D)PARTICLE_ID

--- a/epoch3d/src/constants.F90
+++ b/epoch3d/src/constants.F90
@@ -266,6 +266,7 @@ MODULE constants
   INTEGER(i8), PARAMETER :: c_def_use_isatty = 2**24
   INTEGER(i8), PARAMETER :: c_def_use_mpi3 = 2**25
   INTEGER(i8), PARAMETER :: c_def_bremsstrahlung = 2**26
+  INTEGER(i8), PARAMETER :: c_def_wt_interpolation = 2**27
 
   ! Stagger types
   INTEGER, PARAMETER :: c_stagger_ex = c_stagger_face_x

--- a/epoch3d/src/housekeeping/setup.F90
+++ b/epoch3d/src/housekeeping/setup.F90
@@ -764,6 +764,16 @@ CONTAINS
 
     dt = dt_multiplier * dt
 
+#ifdef WT_INTERPOLATION
+    IF (c * dt / MIN(dx, dy, dx) > 0.5_num) THEN
+      IF (rank == 0) THEN
+        PRINT*, '*** ERROR ***'
+        PRINT*, 'Cannot use WT beacause c*dt/min(dx,dy,dx)>0.5'
+      END IF
+      CALL abort_code(c_err_bad_setup)
+    END IF
+#endif
+
     IF (.NOT. any_average) RETURN
 
     DO io = 1, n_io_blocks

--- a/epoch3d/src/housekeeping/welcome.F90
+++ b/epoch3d/src/housekeeping/welcome.F90
@@ -99,6 +99,9 @@ CONTAINS
 #ifdef PARTICLE_SHAPE_TOPHAT
     found = .TRUE.
 #endif
+#ifdef WT_INTERPOLATION
+    found = .TRUE.
+#endif
 #ifdef PER_SPECIES_WEIGHT
     found = .TRUE.
 #endif
@@ -185,6 +188,10 @@ CONTAINS
 #ifdef PARTICLE_SHAPE_TOPHAT
     defines = IOR(defines, c_def_particle_shape_tophat)
     WRITE(*,*) 'Top-hat particle shape -DPARTICLE_SHAPE_TOPHAT'
+#endif
+#ifdef WT_INTERPOLATION
+    defines = IOR(defines, c_def_wt_interpolation)
+    WRITE(*,*) 'WT interpolation scheme -DWT_INTERPOLATION'
 #endif
 #ifdef PER_SPECIES_WEIGHT
     defines = IOR(defines, c_def_per_particle_weight)

--- a/epoch3d/src/include/bspline3/gx_wt.inc
+++ b/epoch3d/src/include/bspline3/gx_wt.inc
@@ -1,0 +1,43 @@
+! IMPORTANT NOTE
+! These weight need to be multiplied by 1/24
+        wt_var1 = wt_facx * (wt_dtx + cell_frac_x)**4
+        wt_var2 = wt_facx * (wt_dtx - cell_frac_x)**4
+        wt_var3 = SIGN(wt_var1, wt_dtx + cell_frac_x) &
+            + SIGN(wt_var2, wt_dtx - cell_frac_x)
+        wt_var4 = ((3.0_num - cell_frac_x) * cell_frac_x + 3.0_num - wt_dtx2) &
+            * cell_frac_x + 1.0_num + wt_dtx2
+        wt_var5 = ((3.0_num + cell_frac_x) * cell_frac_x - 3.0_num + wt_dtx2) &
+            * cell_frac_x + 1.0_num + wt_dtx2
+        gx(-2) = wt_var3 + wt_var1 - wt_var2
+        gx(-1) = 4.0_num * (wt_var4 - wt_var3)
+        gx( 0) = 24.0_num + 6.0_num * wt_var3 - 4.0_num * (wt_var4 + wt_var5)
+        gx( 1) = 4.0_num * (wt_var5 - wt_var3)
+        gx( 2) = wt_var3 + wt_var2 - wt_var1
+
+        wt_var1 = wt_facy * (wt_dty + cell_frac_y)**4
+        wt_var2 = wt_facy * (wt_dty - cell_frac_y)**4
+        wt_var3 = SIGN(wt_var1, wt_dty + cell_frac_y) &
+            + SIGN(wt_var2, wt_dty - cell_frac_y)
+        wt_var4 = ((3.0_num - cell_frac_y) * cell_frac_y + 3.0_num - wt_dty2) &
+            * cell_frac_y + 1.0_num + wt_dty2
+        wt_var5 = ((3.0_num + cell_frac_y) * cell_frac_y - 3.0_num + wt_dty2) &
+            * cell_frac_y + 1.0_num + wt_dty2
+        gy(-2) = wt_var3 + wt_var1 - wt_var2
+        gy(-1) = 4.0_num * (wt_var4 - wt_var3)
+        gy( 0) = 24.0_num + 6.0_num * wt_var3 - 4.0_num * (wt_var4 + wt_var5)
+        gy( 1) = 4.0_num * (wt_var5 - wt_var3)
+        gy( 2) = wt_var3 + wt_var2 - wt_var1
+
+        wt_var1 = wt_facz * (wt_dtz + cell_frac_z)**4
+        wt_var2 = wt_facz * (wt_dtz - cell_frac_z)**4
+        wt_var3 = SIGN(wt_var1, wt_dtz + cell_frac_z) &
+            + SIGN(wt_var2, wt_dtz - cell_frac_z)
+        wt_var4 = ((3.0_num - cell_frac_z) * cell_frac_z + 3.0_num - wt_dtz2) &
+            * cell_frac_z + 1.0_num + wt_dtz2
+        wt_var5 = ((3.0_num + cell_frac_z) * cell_frac_z - 3.0_num + wt_dtz2) &
+            * cell_frac_z + 1.0_num + wt_dtz2
+        gz(-2) = wt_var3 + wt_var1 - wt_var2
+        gz(-1) = 4.0_num * (wt_var4 - wt_var3)
+        gz( 0) = 24.0_num + 6.0_num * wt_var3 - 4.0_num * (wt_var4 + wt_var5)
+        gz( 1) = 4.0_num * (wt_var5 - wt_var3)
+        gz( 2) = wt_var3 + wt_var2 - wt_var1

--- a/epoch3d/src/include/tophat/gx_wt.inc
+++ b/epoch3d/src/include/tophat/gx_wt.inc
@@ -1,0 +1,14 @@
+        wt_var1 = wt_facx * (ABS(wt_dtx + cell_frac_x) &
+            - ABS(wt_dtx - cell_frac_x))
+        gx( 0) = 0.5_num + wt_var1
+        gx( 1) = 0.5_num - wt_var1
+
+        wt_var1 = wt_facy * (ABS(wt_dty + cell_frac_y) &
+            - ABS(wt_dty - cell_frac_y))
+        gy( 0) = 0.5_num + wt_var1
+        gy( 1) = 0.5_num - wt_var1
+
+        wt_var1 = wt_facz * (ABS(wt_dtz + cell_frac_z) &
+            - ABS(wt_dtz - cell_frac_z))
+        gz( 0) = 0.5_num + wt_var1
+        gz( 1) = 0.5_num - wt_var1

--- a/epoch3d/src/include/triangle/gx_wt.inc
+++ b/epoch3d/src/include/triangle/gx_wt.inc
@@ -1,0 +1,22 @@
+! IMPORTANT NOTE
+! These weight need to be multiplied by 1/2
+        wt_var1 = wt_facx * ( &
+            ABS(wt_dtx + cell_frac_x) * (wt_dtx + cell_frac_x) &
+            + ABS(wt_dtx - cell_frac_x) * (wt_dtx - cell_frac_x))
+        gx(-1) = wt_var1 + cell_frac_x
+        gx( 0) = 2.0_num - 2.0_num * wt_var1
+        gx( 1) = wt_var1 - cell_frac_x
+
+        wt_var1 = wt_facy * ( &
+            ABS(wt_dty + cell_frac_y) * (wt_dty + cell_frac_y) &
+            + ABS(wt_dty - cell_frac_y) * (wt_dty - cell_frac_y))
+        gy(-1) = wt_var1 + cell_frac_y
+        gy( 0) = 2.0_num - 2.0_num * wt_var1
+        gy( 1) = wt_var1 - cell_frac_y
+
+        wt_var1 = wt_facz * ( &
+            ABS(wt_dtz + cell_frac_z) * (wt_dtz + cell_frac_z) &
+            + ABS(wt_dtz - cell_frac_z) * (wt_dtz - cell_frac_z))
+        gz(-1) = wt_var1 + cell_frac_z
+        gz( 0) = 2.0_num - 2.0_num * wt_var1
+        gz( 1) = wt_var1 - cell_frac_z

--- a/epoch3d/src/particles.F90
+++ b/epoch3d/src/particles.F90
@@ -341,6 +341,7 @@ CONTAINS
 
         ! For WT scheme, use hx0 to store the weight factors used to weigh
         ! particle properties onto grid at Xi0*. And calculate gx for WT.
+        ! Y. Lu et al., J. Comput. Phys 413, 109388 (2020)
         ! NOTE: These weights require an additional multiplication factor!
 #ifdef WT_INTERPOLATION
         hx0 = gx

--- a/epoch3d/src/particles.F90
+++ b/epoch3d/src/particles.F90
@@ -88,6 +88,14 @@ CONTAINS
     ! This is to deal with the grid stagger
     REAL(num), DIMENSION(sf_min-1:sf_max+1) :: hx, hy, hz
 
+    ! For WT scheme, the weight factors used to weight particle properties onto
+    ! grid to calculate J is same as bspline3, triangle or tophat.  But the
+    ! particle weight factors to weight fields onto particles are not bspline3,
+    ! triangle or tophat. We use hx0 to store the former weight factors at Xi0*.
+#ifdef WT_INTERPOLATION
+    REAL(num), DIMENSION(sf_min-1:sf_max+1) :: hx0, hy0, hz0
+#endif
+
     ! Fields at particle location
     REAL(num) :: ex_part, ey_part, ez_part, bx_part, by_part, bz_part
 
@@ -134,6 +142,15 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_dty, wt_dtz, wt_facx, wt_facy, wt_facz
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2, wt_dty2, wt_dtz2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 #ifdef DELTAF_METHOD
     REAL(num) :: weight_back
 #endif
@@ -151,6 +168,11 @@ CONTAINS
     gx = 0.0_num
     gy = 0.0_num
     gz = 0.0_num
+#ifdef WT_INTERPOLATION
+    hx0 = 0.0_num
+    hy0 = 0.0_num
+    hz0 = 0.0_num
+#endif
 
     ! Unvarying multiplication factors
 
@@ -166,6 +188,20 @@ CONTAINS
     idtyz = idt * idy * idz * fac
     idtxz = idt * idx * idz * fac
     idtxy = idt * idx * idy * fac
+
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_dty = c * dt / dy
+    wt_dtz = c * dt / dz
+    wt_facx = 0.25_num / wt_dtx
+    wt_facy = 0.25_num / wt_dty
+    wt_facz = 0.25_num / wt_dtz
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+    wt_dty2 = wt_dty**2
+    wt_dtz2 = wt_dtz**2
+#endif
+#endif
 
     DO ispecies = 1, n_species
       current => species_list(ispecies)%attached_list%head
@@ -301,6 +337,22 @@ CONTAINS
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+
+        ! For WT scheme, use hx0 to store the weight factors used to weigh
+        ! particle properties onto grid at Xi0*. And calculate gx for WT.
+        ! NOTE: These weights require an additional multiplication factor!
+#ifdef WT_INTERPOLATION
+        hx0 = gx
+        hy0 = gy
+        hz0 = gz
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
         ! Now redo shifted by half a cell due to grid stagger.
@@ -499,6 +551,11 @@ CONTAINS
 
           ! Now change Xi1* to be Xi1*-Xi0*. This makes the representation of
           ! the current update much simpler
+#ifdef WT_INTERPOLATION
+          gx = hx0
+          gy = hy0
+          gz = hz0
+#endif
           hx = hx - gx
           hy = hy - gy
           hz = hz - gz

--- a/epoch3d/src/physics_packages/ionise.F90
+++ b/epoch3d/src/physics_packages/ionise.F90
@@ -449,12 +449,35 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_dty, wt_dtz, wt_facx, wt_facy, wt_facz
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2, wt_dty2, wt_dtz2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 
     idx = 1.0_num / dx
     idy = 1.0_num / dy
     idz = 1.0_num / dz
 
     dfac = fac**2 / dt / dx / dy / dz
+
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_dty = c * dt / dy
+    wt_dtz = c * dt / dz
+    wt_facx = 0.25_num / wt_dtx
+    wt_facy = 0.25_num / wt_dty
+    wt_facz = 0.25_num / wt_dtz
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+    wt_dty2 = wt_dty**2
+    wt_dtz2 = wt_dtz**2
+#endif
+#endif
 
     ! Stores ionised species until close of ionisation run. Main purpose of this
     ! method is to ensure proper statistics (i.e. prevent ionisation rate being
@@ -510,12 +533,22 @@ CONTAINS
         ! Also used to weight particle properties onto grid, used later
         ! to calculate J
         ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/gx.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
         ! Now redo shifted by half a cell due to grid stagger.
@@ -752,12 +785,35 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_dty, wt_dtz, wt_facx, wt_facy, wt_facz
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2, wt_dty2, wt_dtz2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 
     idx = 1.0_num / dx
     idy = 1.0_num / dy
     idz = 1.0_num / dz
 
     dfac = fac**2 / dt / dx / dy / dz
+
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_dty = c * dt / dy
+    wt_dtz = c * dt / dz
+    wt_facx = 0.25_num / wt_dtx
+    wt_facy = 0.25_num / wt_dty
+    wt_facz = 0.25_num / wt_dtz
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+    wt_dty2 = wt_dty**2
+    wt_dtz2 = wt_dtz**2
+#endif
+#endif
 
     ! Stores ionised species until close of ionisation run. Main purpose of this
     ! method is to ensure proper statistics (i.e. prevent ionisation rate being
@@ -813,12 +869,22 @@ CONTAINS
         ! Also used to weight particle properties onto grid, used later
         ! to calculate J
         ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/gx.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
         ! Now redo shifted by half a cell due to grid stagger.
@@ -1041,6 +1107,15 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_dty, wt_dtz, wt_facx, wt_facy, wt_facz
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2, wt_dty2, wt_dtz2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 
     idx = 1.0_num / dx
     idy = 1.0_num / dy
@@ -1048,6 +1123,20 @@ CONTAINS
 
     dfac = fac**2 / dt / dx / dy / dz
 
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_dty = c * dt / dy
+    wt_dtz = c * dt / dz
+    wt_facx = 0.25_num / wt_dtx
+    wt_facy = 0.25_num / wt_dty
+    wt_facz = 0.25_num / wt_dtz
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+    wt_dty2 = wt_dty**2
+    wt_dtz2 = wt_dtz**2
+#endif
+#endif
+ 
     ! Stores ionised species until close of ionisation run. Main purpose of this
     ! method is to ensure proper statistics (i.e. prevent ionisation rate being
     ! calculated for full dt when particle has already ionised in time step)
@@ -1102,12 +1191,22 @@ CONTAINS
         ! Also used to weight particle properties onto grid, used later
         ! to calculate J
         ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/gx.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
         ! Now redo shifted by half a cell due to grid stagger.
@@ -1320,12 +1419,35 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_dty, wt_dtz, wt_facx, wt_facy, wt_facz
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2, wt_dty2, wt_dtz2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 
     idx = 1.0_num / dx
     idy = 1.0_num / dy
     idz = 1.0_num / dz
 
     dfac = fac**2 / dt / dx / dy / dz
+
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_dty = c * dt / dy
+    wt_dtz = c * dt / dz
+    wt_facx = 0.25_num / wt_dtx
+    wt_facy = 0.25_num / wt_dty
+    wt_facz = 0.25_num / wt_dtz
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+    wt_dty2 = wt_dty**2
+    wt_dtz2 = wt_dtz**2
+#endif
+#endif
 
     ! Stores ionised species until close of ionisation run. Main purpose of this
     ! method is to ensure proper statistics (i.e. prevent ionisation rate being
@@ -1381,12 +1503,22 @@ CONTAINS
         ! Also used to weight particle properties onto grid, used later
         ! to calculate J
         ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/gx.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
         ! Now redo shifted by half a cell due to grid stagger.

--- a/epoch3d/src/physics_packages/photons.F90
+++ b/epoch3d/src/physics_packages/photons.F90
@@ -782,7 +782,30 @@ CONTAINS
     REAL(num) :: cf2
     REAL(num), PARAMETER :: fac = (0.5_num)**c_ndims
 #endif
+    ! Factors for WT scheme
+#ifdef WT_INTERPOLATION
+    REAL(num) :: wt_dtx, wt_dty, wt_dtz, wt_facx, wt_facy, wt_facz
+    REAL(num) :: wt_var1
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    REAL(num) :: wt_dtx2, wt_dty2, wt_dtz2
+    REAL(num) :: wt_var2, wt_var3, wt_var4, wt_var5
+#endif
+#endif
 
+    ! Unvarying factors for WT scheme
+#ifdef WT_INTERPOLATION
+    wt_dtx = c * dt / dx
+    wt_dty = c * dt / dy
+    wt_dtz = c * dt / dz
+    wt_facx = 0.25_num / wt_dtx
+    wt_facy = 0.25_num / wt_dty
+    wt_facz = 0.25_num / wt_dtz
+#ifdef PARTICLE_SHAPE_BSPLINE3
+    wt_dtx2 = wt_dtx**2
+    wt_dty2 = wt_dty**2
+    wt_dtz2 = wt_dtz**2
+#endif
+#endif
     ! Grid cell position as a fraction.
 #ifdef PARTICLE_SHAPE_TOPHAT
     cell_x_r = part_x / dx - 0.5_num
@@ -812,12 +835,22 @@ CONTAINS
     ! Also used to weight particle properties onto grid, used later
     ! to calculate J
     ! NOTE: These weights require an additional multiplication factor!
+#ifndef WT_INTERPOLATION
 #ifdef PARTICLE_SHAPE_BSPLINE3
 #include "bspline3/gx.inc"
 #elif  PARTICLE_SHAPE_TOPHAT
 #include "tophat/gx.inc"
 #else
 #include "triangle/gx.inc"
+#endif
+#else
+#ifdef PARTICLE_SHAPE_BSPLINE3
+#include "bspline3/gx_wt.inc"
+#elif  PARTICLE_SHAPE_TOPHAT
+#include "tophat/gx_wt.inc"
+#else
+#include "triangle/gx_wt.inc"
+#endif
 #endif
 
     ! Now redo shifted by half a cell due to grid stagger.


### PR DESCRIPTION
Implemented time-step dependent force interpolation scheme (WT scheme) for suppressing numerical instability in relativistic drifting simulations according to [Y. Lu et al., J. Comput. Phys 413, 109388 (2020)](https://doi.org/10.1016/j.jcp.2020.109388). WT scheme can be switched on by the flag for preprocessor `DEFINES += $(D)WT_INTERPOLATION` in Makefile.
