### PR TITLE
classic spin precession

### DIFF
--- a/epoch1d/Makefile
+++ b/epoch1d/Makefile
@@ -214,6 +214,9 @@ DEFINES := $(DEFINE)
 # Include QED routines
 #DEFINES += $(D)PHOTONS
 
+# Include the particle spin. Spin precession is calculated via the T-BMT equations
+DEFINES += $(D)PARTICLE_SPIN
+
 # Use the Trident process for pair production
 #DEFINES += $(D)TRIDENT_PHOTONS
 

--- a/epoch1d/src/constants.F90
+++ b/epoch1d/src/constants.F90
@@ -216,6 +216,9 @@ MODULE constants
   REAL(num), PARAMETER :: log_plasma_screen_const_2 = &
       LOG(SQRT(epsilon0 * kb) / q0 * m0 * c * alpha / 1.4_num / h_bar)
 #endif
+#ifdef PARTICLE_SPIN
+  REAL(num), PARAMETER :: anomalous_magnetic_moment = 0.0011614_num
+#endif
 
   ! define special particle IDs
   INTEGER, PARAMETER :: c_species_id_generic = 0
@@ -608,7 +611,10 @@ MODULE constants
   INTEGER, PARAMETER :: c_dump_part_work_y_total = 69
   INTEGER, PARAMETER :: c_dump_part_work_z_total = 70
   INTEGER, PARAMETER :: c_dump_part_opdepth_brem = 71
-  INTEGER, PARAMETER :: num_vars_to_dump         = 71
+  INTEGER, PARAMETER :: c_dump_part_spin_x       = 72
+  INTEGER, PARAMETER :: c_dump_part_spin_y       = 73
+  INTEGER, PARAMETER :: c_dump_part_spin_z       = 74
+  INTEGER, PARAMETER :: num_vars_to_dump         = 74
 
   INTEGER, PARAMETER :: c_subset_random     = 1
   INTEGER, PARAMETER :: c_subset_gamma_min  = 2

--- a/epoch1d/src/deck/deck_io_block.F90
+++ b/epoch1d/src/deck/deck_io_block.F90
@@ -611,6 +611,17 @@ CONTAINS
       elementselected = c_dump_part_work_z_total
 #endif
 
+#ifdef PARTICLE_SPIN
+    ELSE IF (str_cmp(element, 'spin_x')) THEN
+      elementselected = c_dump_part_spin_x
+
+    ELSE IF (str_cmp(element, 'spin_y')) THEN
+      elementselected = c_dump_part_spin_y
+
+    ELSE IF (str_cmp(element, 'spin_z')) THEN
+      elementselected = c_dump_part_spin_z
+#endif
+
     ELSE IF (str_cmp(element, 'ex')) THEN
       elementselected = c_dump_ex
 
@@ -1089,6 +1100,14 @@ CONTAINS
 #ifdef BREMSSTRAHLUNG
     io_block%dumpmask(c_dump_part_opdepth_brem) = &
         IOR(io_block%dumpmask(c_dump_part_opdepth_brem), c_io_restartable)
+#endif
+#ifdef PARTICLE_SPIN
+    io_block%dumpmask(c_dump_part_spin_x) = &
+        IOR(io_block%dumpmask(c_dump_part_spin_x), c_io_restartable)
+    io_block%dumpmask(c_dump_part_spin_y) = &
+        IOR(io_block%dumpmask(c_dump_part_spin_y), c_io_restartable)
+    io_block%dumpmask(c_dump_part_spin_z) = &
+        IOR(io_block%dumpmask(c_dump_part_spin_z), c_io_restartable)
 #endif
 #if defined(PARTICLE_ID) || defined(PARTICLE_ID4)
     io_block%dumpmask(c_dump_part_id) = &

--- a/epoch1d/src/housekeeping/partlist.F90
+++ b/epoch1d/src/housekeeping/partlist.F90
@@ -76,6 +76,9 @@ CONTAINS
 #ifdef WORK_DONE_INTEGRATED
     nvar = nvar+6
 #endif
+#ifdef PARTICLE_SPIN
+    nvar = nvar+3
+#endif
     ! Persistent IDs
     IF (any_persistent_subset) nvar = nvar+1
 
@@ -470,6 +473,10 @@ CONTAINS
     array(cpos+5) = a_particle%work_z_total
     cpos = cpos+6
 #endif
+#ifdef PARTICLE_SPIN
+    array(cpos:cpos+2) = a_particle%spin
+    cpos = cpos+3
+#endif
     IF (any_persistent_subset) THEN
       temp_i8 = id_registry%map(a_particle)
       array(cpos) = TRANSFER(temp_i8, 1.0_num)
@@ -545,6 +552,10 @@ CONTAINS
     a_particle%work_z_total = array(cpos+5)
     cpos = cpos+6
 #endif
+#ifdef PARTICLE_SPIN
+    a_particle%spin = array(cpos:cpos+2)
+    cpos = cpos+3
+#endif
     IF (any_persistent_subset) THEN
       CALL id_registry%add_with_map(a_particle, TRANSFER(array(cpos), temp_i8))
       cpos = cpos+1
@@ -591,7 +602,9 @@ CONTAINS
     new_particle%optical_depth_bremsstrahlung = &
         LOG(1.0_num / (1.0_num - random()))
 #endif
-
+#ifdef PARTICLE_SPIN
+    new_particle%spin = (/0.0, 0.0, 1.0/)
+#endif
   END SUBROUTINE init_particle
 
 

--- a/epoch1d/src/io/diagnostics.F90
+++ b/epoch1d/src/io/diagnostics.F90
@@ -660,6 +660,14 @@ CONTAINS
         CALL write_particle_variable(c_dump_part_work_z_total, code, &
             'Time_Integrated_Work_z', 'J', it_output_real)
 #endif
+#ifdef PARTICLE_SPIN
+        CALL write_particle_variable(c_dump_part_spin_x, code, &
+            'Spin_x', '', it_output_real)
+        CALL write_particle_variable(c_dump_part_spin_y, code, &
+            'Spin_y', '', it_output_real)
+        CALL write_particle_variable(c_dump_part_spin_z, code, &
+            'Spin_z', '', it_output_real)
+#endif
         CALL write_particle_grid(code)
 
         ! These are derived variables from the particles

--- a/epoch1d/src/io/iterators.F90
+++ b/epoch1d/src/io/iterators.F90
@@ -341,6 +341,32 @@ CONTAINS
           cur => cur%next
         END DO
 #endif
+
+#ifdef PARTICLE_SPIN
+      CASE (c_dump_part_spin_x)
+        ndim = 1
+        DO WHILE (ASSOCIATED(cur) .AND. (part_count < npoint_it))
+          part_count = part_count + 1
+          array(part_count) = cur%spin(ndim)
+          cur => cur%next
+        END DO
+
+      CASE (c_dump_part_spin_y)
+        ndim = 2
+        DO WHILE (ASSOCIATED(cur) .AND. (part_count < npoint_it))
+          part_count = part_count + 1
+          array(part_count) = cur%spin(ndim)
+          cur => cur%next
+        END DO
+
+      CASE (c_dump_part_spin_z)
+        ndim = 3
+        DO WHILE (ASSOCIATED(cur) .AND. (part_count < npoint_it))
+          part_count = part_count + 1
+          array(part_count) = cur%spin(ndim)
+          cur => cur%next
+        END DO
+#endif
       END SELECT
       ! If the current partlist is exhausted, switch to the next one
       IF (.NOT. ASSOCIATED(cur)) CALL advance_particle_list(current_list, cur)

--- a/epoch1d/src/particles.F90
+++ b/epoch1d/src/particles.F90
@@ -131,6 +131,13 @@ CONTAINS
 #ifdef DELTAF_METHOD
     REAL(num) :: weight_back
 #endif
+#ifdef PARTICLE_SPIN
+    REAL(num) :: part_sx, part_sy, part_sz
+    REAL(num) :: vx_avg, vy_avg, vz_avg
+    REAL(num) :: v_avg_dot_B, spin_f1, spin_f2, spin_f3
+    REAL(num) :: spin_rotation_x, spin_rotation_y, spin_rotation_z
+    REAL(num) :: spin_spx, spin_spy, spin_spz
+#endif
 
     TYPE(particle), POINTER :: current, next
     TYPE(particle_pointer_list), POINTER :: bnd_part_last, bnd_part_next
@@ -390,6 +397,84 @@ CONTAINS
 
         ! Move particles to end of time step at 2nd order accuracy
         part_x = part_x + delta_x
+
+#ifdef PARTICLE_SPIN
+        part_sx = current%spin(1)
+        part_sy = current%spin(2)
+        part_sz = current%spin(3)
+
+        ! repeating the Boris rotation on the velocity with half the timestep
+        ! to get the time staggered velocity
+        taux = 0.5_num * bx_part * root
+        tauy = 0.5_num * by_part * root
+        tauz = 0.5_num * bz_part * root
+
+        taux2 = taux**2
+        tauy2 = tauy**2
+        tauz2 = tauz**2
+
+        tau = 1.0_num / (1.0_num + taux2 + tauy2 + tauz2)
+
+        ! the normalised velocity v/c at the half time step
+        vx_avg = (((1.0_num + taux2 - tauy2 - tauz2) * uxm &
+            + 2.0_num * ((taux * tauy + tauz) * uym &
+            + (taux * tauz - tauy) * uzm)) * tau) / gamma_rel
+        vy_avg = (((1.0_num - taux2 + tauy2 - tauz2) * uym &
+            + 2.0_num * ((tauy * tauz + taux) * uzm &
+            + (tauy * taux - tauz) * uxm)) * tau) / gamma_rel
+        vz_avg = (((1.0_num - taux2 - tauy2 + tauz2) * uzm &
+            + 2.0_num * ((tauz * taux + tauy) * uxm &
+            + (tauz * tauy - taux) * uym)) * tau) / gamma_rel
+
+        ! ds/dt = s x spin_rotation
+        ! with
+        ! spin_rotation = - dt/2 e/m [(a + 1/gamma)(B - (v/c)x(E/c)) 
+        !    - (v/c) (a gamma/(gamma + 1)) (v/c) . B]
+        v_avg_dot_B = vx_avg * bx_part + vy_avg * by_part + vz_avg*bz_part
+        
+        spin_f1 = part_q * (anomalous_magnetic_moment + 1 / gamma_rel) / part_m
+        spin_f2 = part_q * anomalous_magnetic_moment * gamma_rel &
+            / ((1.0_num + gamma_rel) * part_m)
+
+        spin_rotation_x = - dtfac * (spin_f1 * ( bx_part &
+            - (vy_avg * ez_part - vz_avg * ey_part) / c) &
+            - spin_f2 * vx_avg * v_avg_dot_B)
+
+        spin_rotation_y = - dtfac * (spin_f1 * ( by_part &
+            - (vz_avg * ex_part - vx_avg * ez_part) / c) &
+            - spin_f2 * vy_avg * v_avg_dot_B)
+
+        spin_rotation_z = - dtfac * (spin_f1 * ( bz_part &
+            - (vx_avg * ey_part - vy_avg * ex_part) / c) &
+            - spin_f2 * vz_avg * v_avg_dot_B)
+
+        ! now perform a Boris-style rotation on the spin vector
+        ! spin_sp = spin_old + spin_old x spin_rotation
+        ! spin_new = spin_old 
+        !     + 2 spin_sp x spin_rotation / ( 1 + |spin_rotation|^2 )
+
+        spin_f3 = 2.0_num / (1 + spin_rotation_x*spin_rotation_x &
+            + spin_rotation_y * spin_rotation_y &
+            + spin_rotation_z * spin_rotation_z)
+
+        spin_spx = part_sx + part_sy * spin_rotation_z &
+          - part_sz * spin_rotation_y
+
+        spin_spy = part_sy + part_sz * spin_rotation_x &
+          - part_sx * spin_rotation_z
+
+        spin_spz = part_sz + part_sx * spin_rotation_y &
+          - part_sy * spin_rotation_x
+
+        current%spin(1) = part_sx + spin_f3 * (spin_spy * spin_rotation_z &
+            - spin_spz * spin_rotation_y)
+
+        current%spin(2) = part_sy + spin_f3 * (spin_spz * spin_rotation_x &
+            - spin_spx * spin_rotation_z)
+
+        current%spin(3) = part_sz + spin_f3 * (spin_spx * spin_rotation_y &
+            - spin_spy * spin_rotation_x)
+#endif
 
         ! particle has now finished move to end of timestep, so copy back
         ! into particle array

--- a/epoch1d/src/shared_data.F90
+++ b/epoch1d/src/shared_data.F90
@@ -136,6 +136,9 @@ MODULE shared_data
 #ifdef BREMSSTRAHLUNG
     REAL(num) :: optical_depth_bremsstrahlung
 #endif
+#ifdef PARTICLE_SPIN
+    REAL(num), DIMENSION(3) :: spin
+#endif
   END TYPE particle
 
   ! Data for migration between species

--- a/epoch2d/Makefile
+++ b/epoch2d/Makefile
@@ -214,6 +214,9 @@ DEFINES := $(DEFINE)
 # Include QED routines
 #DEFINES += $(D)PHOTONS
 
+# Include the particle spin. Spin precession is calculated via the T-BMT equations
+DEFINES += $(D)PARTICLE_SPIN
+
 # Use the Trident process for pair production
 #DEFINES += $(D)TRIDENT_PHOTONS
 

--- a/epoch2d/src/constants.F90
+++ b/epoch2d/src/constants.F90
@@ -608,7 +608,10 @@ MODULE constants
   INTEGER, PARAMETER :: c_dump_part_work_y_total = 69
   INTEGER, PARAMETER :: c_dump_part_work_z_total = 70
   INTEGER, PARAMETER :: c_dump_part_opdepth_brem = 71
-  INTEGER, PARAMETER :: num_vars_to_dump         = 71
+  INTEGER, PARAMETER :: c_dump_part_spin_x       = 72
+  INTEGER, PARAMETER :: c_dump_part_spin_y       = 73
+  INTEGER, PARAMETER :: c_dump_part_spin_z       = 74
+  INTEGER, PARAMETER :: num_vars_to_dump         = 74
 
   INTEGER, PARAMETER :: c_subset_random     = 1
   INTEGER, PARAMETER :: c_subset_gamma_min  = 2

--- a/epoch2d/src/constants.F90
+++ b/epoch2d/src/constants.F90
@@ -216,6 +216,9 @@ MODULE constants
   REAL(num), PARAMETER :: log_plasma_screen_const_2 = &
       LOG(SQRT(epsilon0 * kb) / q0 * m0 * c * alpha / 1.4_num / h_bar)
 #endif
+#ifdef PARTICLE_SPIN
+  REAL(num), PARAMETER :: anomalous_magnetic_moment = 0.0011614_num
+#endif
 
   ! define special particle IDs
   INTEGER, PARAMETER :: c_species_id_generic = 0

--- a/epoch2d/src/deck/deck_io_block.F90
+++ b/epoch2d/src/deck/deck_io_block.F90
@@ -612,6 +612,17 @@ CONTAINS
       elementselected = c_dump_part_work_z_total
 #endif
 
+#ifdef PARTICLE_SPIN
+    ELSE IF (str_cmp(element, 'spin_x')) THEN
+      elementselected = c_dump_part_spin_x
+
+    ELSE IF (str_cmp(element, 'spin_y')) THEN
+      elementselected = c_dump_part_work_y
+
+    ELSE IF (str_cmp(element, 'spin_z')) THEN
+      elementselected = c_dump_part_work_z
+#endif
+
     ELSE IF (str_cmp(element, 'ex')) THEN
       elementselected = c_dump_ex
 
@@ -1102,6 +1113,14 @@ CONTAINS
 #ifdef BREMSSTRAHLUNG
     io_block%dumpmask(c_dump_part_opdepth_brem) = &
         IOR(io_block%dumpmask(c_dump_part_opdepth_brem), c_io_restartable)
+#endif
+#ifdef PARTICLE_SPIN
+    io_block%dumpmask(c_dump_part_spin_x) = &
+        IOR(io_block%dumpmask(c_dump_part_spin_x), c_io_restartable)
+    io_block%dumpmask(c_dump_part_spin_y) = &
+        IOR(io_block%dumpmask(c_dump_part_spin_y), c_io_restartable)
+    io_block%dumpmask(c_dump_part_spin_z) = &
+        IOR(io_block%dumpmask(c_dump_part_spin_z), c_io_restartable)
 #endif
 #if defined(PARTICLE_ID) || defined(PARTICLE_ID4)
     io_block%dumpmask(c_dump_part_id) = &

--- a/epoch2d/src/deck/deck_io_block.F90
+++ b/epoch2d/src/deck/deck_io_block.F90
@@ -617,10 +617,10 @@ CONTAINS
       elementselected = c_dump_part_spin_x
 
     ELSE IF (str_cmp(element, 'spin_y')) THEN
-      elementselected = c_dump_part_work_y
+      elementselected = c_dump_part_spin_y
 
     ELSE IF (str_cmp(element, 'spin_z')) THEN
-      elementselected = c_dump_part_work_z
+      elementselected = c_dump_part_spin_z
 #endif
 
     ELSE IF (str_cmp(element, 'ex')) THEN

--- a/epoch2d/src/housekeeping/partlist.F90
+++ b/epoch2d/src/housekeeping/partlist.F90
@@ -603,7 +603,7 @@ CONTAINS
         LOG(1.0_num / (1.0_num - random()))
 #endif
 #ifdef PARTICLE_SPIN
-    new_particle%spin = (/1.0, 0.0, 0.0/)
+    new_particle%spin = (/0.0, 0.0, 1.0/)
 #endif
   END SUBROUTINE init_particle
 

--- a/epoch2d/src/housekeeping/partlist.F90
+++ b/epoch2d/src/housekeeping/partlist.F90
@@ -76,6 +76,9 @@ CONTAINS
 #ifdef WORK_DONE_INTEGRATED
     nvar = nvar+6
 #endif
+#ifdef PARTICLE_SPIN
+    nvar = nvar+3
+#endif
     ! Persistent IDs
     IF (any_persistent_subset) nvar = nvar+1
 
@@ -470,6 +473,10 @@ CONTAINS
     array(cpos+5) = a_particle%work_z_total
     cpos = cpos+6
 #endif
+#ifdef PARTICLE_SPIN
+    array(cpos:cpos+2) = a_particle%spin
+    cpos = cpos+3
+#endif
     IF (any_persistent_subset) THEN
       temp_i8 = id_registry%map(a_particle)
       array(cpos) = TRANSFER(temp_i8, 1.0_num)
@@ -545,6 +552,10 @@ CONTAINS
     a_particle%work_z_total = array(cpos+5)
     cpos = cpos+6
 #endif
+#ifdef PARTICLE_SPIN
+    a_particle%spin = array(cpos:cpos+2)
+    cpos = cpos+3
+#endif
     IF (any_persistent_subset) THEN
       CALL id_registry%add_with_map(a_particle, TRANSFER(array(cpos), temp_i8))
       cpos = cpos+1
@@ -591,7 +602,9 @@ CONTAINS
     new_particle%optical_depth_bremsstrahlung = &
         LOG(1.0_num / (1.0_num - random()))
 #endif
-
+#ifdef PARTICLE_SPIN
+    new_particle%spin = (/1.0, 0.0, 0.0/)
+#endif
   END SUBROUTINE init_particle
 
 

--- a/epoch2d/src/io/diagnostics.F90
+++ b/epoch2d/src/io/diagnostics.F90
@@ -671,11 +671,11 @@ CONTAINS
 #endif
 #ifdef PARTICLE_SPIN
         CALL write_particle_variable(c_dump_part_spin_x, code, &
-            'Spin_x_direction', '', it_output_real)
-        CALL write_particle_variable(c_dump_part_spin_x, code, &
-            'Spin_x_direction', '', it_output_real)
-        CALL write_particle_variable(c_dump_part_spin_x, code, &
-            'Spin_x_direction', '', it_output_real)
+            'Spin_x', '', it_output_real)
+        CALL write_particle_variable(c_dump_part_spin_y, code, &
+            'Spin_y', '', it_output_real)
+        CALL write_particle_variable(c_dump_part_spin_z, code, &
+            'Spin_z', '', it_output_real)
 #endif
         CALL write_particle_grid(code)
 

--- a/epoch2d/src/io/diagnostics.F90
+++ b/epoch2d/src/io/diagnostics.F90
@@ -669,6 +669,14 @@ CONTAINS
         CALL write_particle_variable(c_dump_part_work_z_total, code, &
             'Time_Integrated_Work_z', 'J', it_output_real)
 #endif
+#ifdef PARTICLE_SPIN
+        CALL write_particle_variable(c_dump_part_spin_x, code, &
+            'Spin_x_direction', '', it_output_real)
+        CALL write_particle_variable(c_dump_part_spin_x, code, &
+            'Spin_x_direction', '', it_output_real)
+        CALL write_particle_variable(c_dump_part_spin_x, code, &
+            'Spin_x_direction', '', it_output_real)
+#endif
         CALL write_particle_grid(code)
 
         ! These are derived variables from the particles

--- a/epoch2d/src/io/iterators.F90
+++ b/epoch2d/src/io/iterators.F90
@@ -341,6 +341,32 @@ CONTAINS
           cur => cur%next
         END DO
 #endif
+
+#ifdef PARTICLE_SPIN
+      CASE (c_dump_part_spin_x)
+        ndim = 1
+        DO WHILE (ASSOCIATED(cur) .AND. (part_count < npoint_it))
+          part_count = part_count + 1
+          array(part_count) = cur%spin(ndim)
+          cur => cur%next
+        END DO
+
+      CASE (c_dump_part_spin_y)
+        ndim = 2
+        DO WHILE (ASSOCIATED(cur) .AND. (part_count < npoint_it))
+          part_count = part_count + 1
+          array(part_count) = cur%spin(ndim)
+          cur => cur%next
+        END DO
+
+      CASE (c_dump_part_spin_z)
+        ndim = 3
+        DO WHILE (ASSOCIATED(cur) .AND. (part_count < npoint_it))
+          part_count = part_count + 1
+          array(part_count) = cur%spin(ndim)
+          cur => cur%next
+        END DO
+#endif
       END SELECT
       ! If the current partlist is exhausted, switch to the next one
       IF (.NOT. ASSOCIATED(cur)) CALL advance_particle_list(current_list, cur)

--- a/epoch2d/src/particles.F90
+++ b/epoch2d/src/particles.F90
@@ -470,7 +470,7 @@ CONTAINS
 
         ! ds/dt = s x spin_rotation
         ! with
-        ! spin_rotation = dt/2 e/m [(a + 1/gamma)(B - (v/c)x(E/c)) 
+        ! spin_rotation = - dt/2 e/m [(a + 1/gamma)(B - (v/c)x(E/c)) 
         !    - (v/c) (a gamma/(gamma + 1)) (v/c) . B]
         v_avg_dot_B = vx_avg * bx_part + vy_avg * by_part + vz_avg*bz_part
         
@@ -478,15 +478,15 @@ CONTAINS
         spin_f2 = part_q * anomalous_magnetic_moment * gamma_rel &
             / ((1.0_num + gamma_rel) * part_m * c**2)
         ! PRINT*, 'SPIN', dto2, gamma_rel, spin_f1, by_part, spin_f1 * by_part
-        spin_rotation_x = dtfac * (spin_f1 * ( bx_part &
+        spin_rotation_x = - dtfac * (spin_f1 * ( bx_part &
             - (vy_avg * ez_part - vz_avg * ey_part) / c**2) &
             - spin_f2 * vx_avg * v_avg_dot_B)
 
-        spin_rotation_y = dtfac * (spin_f1 * ( by_part &
+        spin_rotation_y = - dtfac * (spin_f1 * ( by_part &
             - (vz_avg * ex_part - vx_avg * ez_part) / c**2) &
             - spin_f2 * vy_avg * v_avg_dot_B)
 
-        spin_rotation_z = dtfac * (spin_f1 * ( bz_part &
+        spin_rotation_z = - dtfac * (spin_f1 * ( bz_part &
             - (vx_avg * ey_part - vy_avg * ex_part) / c**2) &
             - spin_f2 * vz_avg * v_avg_dot_B)
 

--- a/epoch2d/src/particles.F90
+++ b/epoch2d/src/particles.F90
@@ -458,15 +458,16 @@ CONTAINS
 
         tau = 1.0_num / (1.0_num + taux2 + tauy2 + tauz2)
 
+        ! the normalised velocity v/c at the half time step
         vx_avg = (((1.0_num + taux2 - tauy2 - tauz2) * uxm &
             + 2.0_num * ((taux * tauy + tauz) * uym &
-            + (taux * tauz - tauy) * uzm)) * tau) / (c*gamma_rel)
+            + (taux * tauz - tauy) * uzm)) * tau) / gamma_rel
         vy_avg = (((1.0_num - taux2 + tauy2 - tauz2) * uym &
             + 2.0_num * ((tauy * tauz + taux) * uzm &
-            + (tauy * taux - tauz) * uxm)) * tau) / (c*gamma_rel)
+            + (tauy * taux - tauz) * uxm)) * tau) / gamma_rel
         vz_avg = (((1.0_num - taux2 - tauy2 + tauz2) * uzm &
             + 2.0_num * ((tauz * taux + tauy) * uxm &
-            + (tauz * tauy - taux) * uym)) * tau) / (c*gamma_rel)
+            + (tauz * tauy - taux) * uym)) * tau) / gamma_rel
 
         ! ds/dt = s x spin_rotation
         ! with
@@ -476,18 +477,18 @@ CONTAINS
         
         spin_f1 = part_q * (anomalous_magnetic_moment + 1 / gamma_rel) / part_m
         spin_f2 = part_q * anomalous_magnetic_moment * gamma_rel &
-            / ((1.0_num + gamma_rel) * part_m * c**2)
+            / ((1.0_num + gamma_rel) * part_m)
         ! PRINT*, 'SPIN', dto2, gamma_rel, spin_f1, by_part, spin_f1 * by_part
         spin_rotation_x = - dtfac * (spin_f1 * ( bx_part &
-            - (vy_avg * ez_part - vz_avg * ey_part) / c**2) &
+            - (vy_avg * ez_part - vz_avg * ey_part) / c) &
             - spin_f2 * vx_avg * v_avg_dot_B)
 
         spin_rotation_y = - dtfac * (spin_f1 * ( by_part &
-            - (vz_avg * ex_part - vx_avg * ez_part) / c**2) &
+            - (vz_avg * ex_part - vx_avg * ez_part) / c) &
             - spin_f2 * vy_avg * v_avg_dot_B)
 
         spin_rotation_z = - dtfac * (spin_f1 * ( bz_part &
-            - (vx_avg * ey_part - vy_avg * ex_part) / c**2) &
+            - (vx_avg * ey_part - vy_avg * ex_part) / c) &
             - spin_f2 * vz_avg * v_avg_dot_B)
 
         ! now perform a Boris-style rotation on the spin vector

--- a/epoch2d/src/particles.F90
+++ b/epoch2d/src/particles.F90
@@ -472,21 +472,22 @@ CONTAINS
         ! with
         ! spin_rotation = dt/2 e/m [(a + 1/gamma)(B - (v/c)x(E/c)) 
         !    - (v/c) (a gamma/(gamma + 1)) (v/c) . B]
-        v_avg_dot_B = vx_avg * bx_part + vy_avg * by_part + vz_avg * bz_part
+        v_avg_dot_B = vx_avg * bx_part + vy_avg * by_part + vz_avg*bz_part
         
-        spin_f1 = anomalous_magnetic_moment + 1 / gamma_rel
-        spin_f2 = anomalous_magnetic_moment * gamma_rel / (1.0_num + gamma_rel)
-
-        spin_rotation_x = dto2 * (spin_f1 * ( bx_part &
-            - (vy_avg * ez_part - vz_avg * ey_part) / c) &
+        spin_f1 = part_q * (anomalous_magnetic_moment + 1 / gamma_rel) / part_m
+        spin_f2 = part_q * anomalous_magnetic_moment * gamma_rel &
+            / ((1.0_num + gamma_rel) * part_m * c**2)
+        ! PRINT*, 'SPIN', dto2, gamma_rel, spin_f1, by_part, spin_f1 * by_part
+        spin_rotation_x = dtfac * (spin_f1 * ( bx_part &
+            - (vy_avg * ez_part - vz_avg * ey_part) / c**2) &
             - spin_f2 * vx_avg * v_avg_dot_B)
 
-        spin_rotation_y = dto2 * (spin_f1 * ( by_part &
-            - (vz_avg * ex_part - vx_avg * ez_part) / c) &
+        spin_rotation_y = dtfac * (spin_f1 * ( by_part &
+            - (vz_avg * ex_part - vx_avg * ez_part) / c**2) &
             - spin_f2 * vy_avg * v_avg_dot_B)
 
-        spin_rotation_z = dto2 * (spin_f1 * ( bz_part &
-            - (vx_avg * ey_part - vy_avg * ex_part) / c) &
+        spin_rotation_z = dtfac * (spin_f1 * ( bz_part &
+            - (vx_avg * ey_part - vy_avg * ex_part) / c**2) &
             - spin_f2 * vz_avg * v_avg_dot_B)
 
         ! now perform a Boris-style rotation on the spin vector

--- a/epoch2d/src/shared_data.F90
+++ b/epoch2d/src/shared_data.F90
@@ -136,6 +136,9 @@ MODULE shared_data
 #ifdef BREMSSTRAHLUNG
     REAL(num) :: optical_depth_bremsstrahlung
 #endif
+#ifdef PARTICLE_SPIN
+    REAL(num), DIMENSION(3) :: spin
+#endif
   END TYPE particle
 
   ! Data for migration between species

--- a/epoch3d/Makefile
+++ b/epoch3d/Makefile
@@ -214,6 +214,9 @@ DEFINES := $(DEFINE)
 # Include QED routines
 #DEFINES += $(D)PHOTONS
 
+# Include the particle spin. Spin precession is calculated via the T-BMT equations
+DEFINES += $(D)PARTICLE_SPIN
+
 # Use the Trident process for pair production
 #DEFINES += $(D)TRIDENT_PHOTONS
 

--- a/epoch3d/src/constants.F90
+++ b/epoch3d/src/constants.F90
@@ -216,6 +216,9 @@ MODULE constants
   REAL(num), PARAMETER :: log_plasma_screen_const_2 = &
       LOG(SQRT(epsilon0 * kb) / q0 * m0 * c * alpha / 1.4_num / h_bar)
 #endif
+#ifdef PARTICLE_SPIN
+  REAL(num), PARAMETER :: anomalous_magnetic_moment = 0.0011614_num
+#endif
 
   ! define special particle IDs
   INTEGER, PARAMETER :: c_species_id_generic = 0
@@ -608,7 +611,10 @@ MODULE constants
   INTEGER, PARAMETER :: c_dump_part_work_y_total = 69
   INTEGER, PARAMETER :: c_dump_part_work_z_total = 70
   INTEGER, PARAMETER :: c_dump_part_opdepth_brem = 71
-  INTEGER, PARAMETER :: num_vars_to_dump         = 71
+  INTEGER, PARAMETER :: c_dump_part_spin_x       = 72
+  INTEGER, PARAMETER :: c_dump_part_spin_y       = 73
+  INTEGER, PARAMETER :: c_dump_part_spin_z       = 74
+  INTEGER, PARAMETER :: num_vars_to_dump         = 74
 
   INTEGER, PARAMETER :: c_subset_random     = 1
   INTEGER, PARAMETER :: c_subset_gamma_min  = 2

--- a/epoch3d/src/deck/deck_io_block.F90
+++ b/epoch3d/src/deck/deck_io_block.F90
@@ -613,6 +613,17 @@ CONTAINS
       elementselected = c_dump_part_work_z_total
 #endif
 
+#ifdef PARTICLE_SPIN
+    ELSE IF (str_cmp(element, 'spin_x')) THEN
+      elementselected = c_dump_part_spin_x
+
+    ELSE IF (str_cmp(element, 'spin_y')) THEN
+      elementselected = c_dump_part_spin_y
+
+    ELSE IF (str_cmp(element, 'spin_z')) THEN
+      elementselected = c_dump_part_spin_z
+#endif
+
     ELSE IF (str_cmp(element, 'ex')) THEN
       elementselected = c_dump_ex
 
@@ -1114,6 +1125,14 @@ CONTAINS
 #ifdef BREMSSTRAHLUNG
     io_block%dumpmask(c_dump_part_opdepth_brem) = &
         IOR(io_block%dumpmask(c_dump_part_opdepth_brem), c_io_restartable)
+#endif
+#ifdef PARTICLE_SPIN
+    io_block%dumpmask(c_dump_part_spin_x) = &
+        IOR(io_block%dumpmask(c_dump_part_spin_x), c_io_restartable)
+    io_block%dumpmask(c_dump_part_spin_y) = &
+        IOR(io_block%dumpmask(c_dump_part_spin_y), c_io_restartable)
+    io_block%dumpmask(c_dump_part_spin_z) = &
+        IOR(io_block%dumpmask(c_dump_part_spin_z), c_io_restartable)
 #endif
 #if defined(PARTICLE_ID) || defined(PARTICLE_ID4)
     io_block%dumpmask(c_dump_part_id) = &

--- a/epoch3d/src/housekeeping/partlist.F90
+++ b/epoch3d/src/housekeeping/partlist.F90
@@ -76,6 +76,9 @@ CONTAINS
 #ifdef WORK_DONE_INTEGRATED
     nvar = nvar+6
 #endif
+#ifdef PARTICLE_SPIN
+    nvar = nvar+3
+#endif
     ! Persistent IDs
     IF (any_persistent_subset) nvar = nvar+1
 
@@ -470,6 +473,10 @@ CONTAINS
     array(cpos+5) = a_particle%work_z_total
     cpos = cpos+6
 #endif
+#ifdef PARTICLE_SPIN
+    array(cpos:cpos+2) = a_particle%spin
+    cpos = cpos+3
+#endif
     IF (any_persistent_subset) THEN
       temp_i8 = id_registry%map(a_particle)
       array(cpos) = TRANSFER(temp_i8, 1.0_num)
@@ -545,6 +552,10 @@ CONTAINS
     a_particle%work_z_total = array(cpos+5)
     cpos = cpos+6
 #endif
+#ifdef PARTICLE_SPIN
+    a_particle%spin = array(cpos:cpos+2)
+    cpos = cpos+3
+#endif
     IF (any_persistent_subset) THEN
       CALL id_registry%add_with_map(a_particle, TRANSFER(array(cpos), temp_i8))
       cpos = cpos+1
@@ -591,7 +602,9 @@ CONTAINS
     new_particle%optical_depth_bremsstrahlung = &
         LOG(1.0_num / (1.0_num - random()))
 #endif
-
+#ifdef PARTICLE_SPIN
+    new_particle%spin = (/0.0, 0.0, 1.0/)
+#endif
   END SUBROUTINE init_particle
 
 

--- a/epoch3d/src/io/diagnostics.F90
+++ b/epoch3d/src/io/diagnostics.F90
@@ -678,6 +678,14 @@ CONTAINS
         CALL write_particle_variable(c_dump_part_work_z_total, code, &
             'Time_Integrated_Work_z', 'J', it_output_real)
 #endif
+#ifdef PARTICLE_SPIN
+        CALL write_particle_variable(c_dump_part_spin_x, code, &
+            'Spin_x', '', it_output_real)
+        CALL write_particle_variable(c_dump_part_spin_y, code, &
+            'Spin_y', '', it_output_real)
+        CALL write_particle_variable(c_dump_part_spin_z, code, &
+            'Spin_z', '', it_output_real)
+#endif
         CALL write_particle_grid(code)
 
         ! These are derived variables from the particles

--- a/epoch3d/src/io/iterators.F90
+++ b/epoch3d/src/io/iterators.F90
@@ -341,6 +341,32 @@ CONTAINS
           cur => cur%next
         END DO
 #endif
+
+#ifdef PARTICLE_SPIN
+      CASE (c_dump_part_spin_x)
+        ndim = 1
+        DO WHILE (ASSOCIATED(cur) .AND. (part_count < npoint_it))
+          part_count = part_count + 1
+          array(part_count) = cur%spin(ndim)
+          cur => cur%next
+        END DO
+
+      CASE (c_dump_part_spin_y)
+        ndim = 2
+        DO WHILE (ASSOCIATED(cur) .AND. (part_count < npoint_it))
+          part_count = part_count + 1
+          array(part_count) = cur%spin(ndim)
+          cur => cur%next
+        END DO
+
+      CASE (c_dump_part_spin_z)
+        ndim = 3
+        DO WHILE (ASSOCIATED(cur) .AND. (part_count < npoint_it))
+          part_count = part_count + 1
+          array(part_count) = cur%spin(ndim)
+          cur => cur%next
+        END DO
+#endif
       END SELECT
       ! If the current partlist is exhausted, switch to the next one
       IF (.NOT. ASSOCIATED(cur)) CALL advance_particle_list(current_list, cur)

--- a/epoch3d/src/particles.F90
+++ b/epoch3d/src/particles.F90
@@ -141,6 +141,13 @@ CONTAINS
 #ifdef DELTAF_METHOD
     REAL(num) :: weight_back
 #endif
+#ifdef PARTICLE_SPIN
+    REAL(num) :: part_sx, part_sy, part_sz
+    REAL(num) :: vx_avg, vy_avg, vz_avg
+    REAL(num) :: v_avg_dot_B, spin_f1, spin_f2, spin_f3
+    REAL(num) :: spin_rotation_x, spin_rotation_y, spin_rotation_z
+    REAL(num) :: spin_spx, spin_spy, spin_spz
+#endif
 
     TYPE(particle), POINTER :: current, next
     TYPE(particle_pointer_list), POINTER :: bnd_part_last, bnd_part_next
@@ -471,6 +478,83 @@ CONTAINS
         part_y = part_y + delta_y
         part_z = part_z + delta_z
 
+#ifdef PARTICLE_SPIN
+        part_sx = current%spin(1)
+        part_sy = current%spin(2)
+        part_sz = current%spin(3)
+
+        ! repeating the Boris rotation on the velocity with half the timestep
+        ! to get the time staggered velocity
+        taux = 0.5_num * bx_part * root
+        tauy = 0.5_num * by_part * root
+        tauz = 0.5_num * bz_part * root
+
+        taux2 = taux**2
+        tauy2 = tauy**2
+        tauz2 = tauz**2
+
+        tau = 1.0_num / (1.0_num + taux2 + tauy2 + tauz2)
+
+        ! the normalised velocity v/c at the half time step
+        vx_avg = (((1.0_num + taux2 - tauy2 - tauz2) * uxm &
+            + 2.0_num * ((taux * tauy + tauz) * uym &
+            + (taux * tauz - tauy) * uzm)) * tau) / gamma_rel
+        vy_avg = (((1.0_num - taux2 + tauy2 - tauz2) * uym &
+            + 2.0_num * ((tauy * tauz + taux) * uzm &
+            + (tauy * taux - tauz) * uxm)) * tau) / gamma_rel
+        vz_avg = (((1.0_num - taux2 - tauy2 + tauz2) * uzm &
+            + 2.0_num * ((tauz * taux + tauy) * uxm &
+            + (tauz * tauy - taux) * uym)) * tau) / gamma_rel
+
+        ! ds/dt = s x spin_rotation
+        ! with
+        ! spin_rotation = - dt/2 e/m [(a + 1/gamma)(B - (v/c)x(E/c)) 
+        !    - (v/c) (a gamma/(gamma + 1)) (v/c) . B]
+        v_avg_dot_B = vx_avg * bx_part + vy_avg * by_part + vz_avg*bz_part
+        
+        spin_f1 = part_q * (anomalous_magnetic_moment + 1 / gamma_rel) / part_m
+        spin_f2 = part_q * anomalous_magnetic_moment * gamma_rel &
+            / ((1.0_num + gamma_rel) * part_m)
+        ! PRINT*, 'SPIN', dto2, gamma_rel, spin_f1, by_part, spin_f1 * by_part
+        spin_rotation_x = - dtfac * (spin_f1 * ( bx_part &
+            - (vy_avg * ez_part - vz_avg * ey_part) / c) &
+            - spin_f2 * vx_avg * v_avg_dot_B)
+
+        spin_rotation_y = - dtfac * (spin_f1 * ( by_part &
+            - (vz_avg * ex_part - vx_avg * ez_part) / c) &
+            - spin_f2 * vy_avg * v_avg_dot_B)
+
+        spin_rotation_z = - dtfac * (spin_f1 * ( bz_part &
+            - (vx_avg * ey_part - vy_avg * ex_part) / c) &
+            - spin_f2 * vz_avg * v_avg_dot_B)
+
+        ! now perform a Boris-style rotation on the spin vector
+        ! spin_sp = spin_old + spin_old x spin_rotation
+        ! spin_new = spin_old 
+        !     + 2 spin_sp x spin_rotation / ( 1 + |spin_rotation|^2 )
+
+        spin_f3 = 2.0_num / (1 + spin_rotation_x*spin_rotation_x &
+            + spin_rotation_y * spin_rotation_y &
+            + spin_rotation_z * spin_rotation_z)
+
+        spin_spx = part_sx + part_sy * spin_rotation_z &
+          - part_sz * spin_rotation_y
+
+        spin_spy = part_sy + part_sz * spin_rotation_x &
+          - part_sx * spin_rotation_z
+
+        spin_spz = part_sz + part_sx * spin_rotation_y &
+          - part_sy * spin_rotation_x
+
+        current%spin(1) = part_sx + spin_f3 * (spin_spy * spin_rotation_z &
+            - spin_spz * spin_rotation_y)
+
+        current%spin(2) = part_sy + spin_f3 * (spin_spz * spin_rotation_x &
+            - spin_spx * spin_rotation_z)
+
+        current%spin(3) = part_sz + spin_f3 * (spin_spx * spin_rotation_y &
+            - spin_spy * spin_rotation_x)
+#endif
         ! particle has now finished move to end of timestep, so copy back
         ! into particle array
         current%part_pos = (/ part_x + x_grid_min_local, &

--- a/epoch3d/src/shared_data.F90
+++ b/epoch3d/src/shared_data.F90
@@ -136,6 +136,9 @@ MODULE shared_data
 #ifdef BREMSSTRAHLUNG
     REAL(num) :: optical_depth_bremsstrahlung
 #endif
+#ifdef PARTICLE_SPIN
+    REAL(num), DIMENSION(3) :: spin
+#endif
   END TYPE particle
 
   ! Data for migration between species


### PR DESCRIPTION
This adds a 3d spin vector to the particle data structure and evolves the spin according to the classic relativistic spin precession given by the T-BMT equation. 

A new macro `PARTICLE_SPIN` is used to enable the particle spin.

The spin precession is implemented using the form of the T-BMT equation given in [1].

`spin_x`, `spin_y` and `spin_z` can be used in the output block to write the spin vector components.


[1] Vieira, J., Huang, C. K., Mori, W. B., & Silva, L. O. (2011). Polarized beam conditioning in plasma based acceleration. Physical Review Special Topics - Accelerators and Beams, 14(7), 071303. https://doi.org/10.1103/PhysRevSTAB.14.071303