### PR TITLE
Fix blunder in field-aligned particle initialisation

### DIFF
--- a/epoch1d/src/user_interaction/helper.F90
+++ b/epoch1d/src/user_interaction/helper.F90
@@ -958,7 +958,7 @@ CONTAINS
     INTEGER(i8), INTENT(IN) :: ipart
     LOGICAL, INTENT(IN) :: x_perp_y_ignored_z_para
     REAL(num), DIMENSION(3,3) :: rotation_matrix
-    REAL(num) :: vperp, gyrophase
+    REAL(num) :: p_perp, gyrophase
     REAL(num), PARAMETER :: golden_angle = pi * (3.0_num - SQRT(5.0_num))
     REAL(num), DIMENSION(3) :: aligned_momentum
 
@@ -967,9 +967,9 @@ CONTAINS
     ! z is the dummy magnetic field direction
     IF (x_perp_y_ignored_z_para) THEN
       gyrophase = golden_angle * ipart
-      vperp = current%part_p(1)
-      aligned_momentum(1) = vperp * COS(gyrophase)
-      aligned_momentum(2) = vperp * SIN(gyrophase)
+      p_perp = current%part_p(1)
+      aligned_momentum(1) = p_perp * COS(gyrophase)
+      aligned_momentum(2) = p_perp * SIN(gyrophase)
       aligned_momentum(3) = current%part_p(3)
     ELSE
       aligned_momentum(1) = current%part_p(1)

--- a/epoch1d/src/user_interaction/helper.F90
+++ b/epoch1d/src/user_interaction/helper.F90
@@ -958,7 +958,7 @@ CONTAINS
     INTEGER(i8), INTENT(IN) :: ipart
     LOGICAL, INTENT(IN) :: x_perp_y_ignored_z_para
     REAL(num), DIMENSION(3,3) :: rotation_matrix
-    REAL(num) :: gyrophase
+    REAL(num) :: vperp, gyrophase
     REAL(num), PARAMETER :: golden_angle = pi * (3.0_num - SQRT(5.0_num))
     REAL(num), DIMENSION(3) :: aligned_momentum
 
@@ -967,8 +967,9 @@ CONTAINS
     ! z is the dummy magnetic field direction
     IF (x_perp_y_ignored_z_para) THEN
       gyrophase = golden_angle * ipart
-      aligned_momentum(1) = current%part_p(1) * COS(gyrophase)
-      aligned_momentum(2) = current%part_p(1) * SIN(gyrophase)
+      vperp = current%part_p(1)
+      aligned_momentum(1) = vperp * COS(gyrophase)
+      aligned_momentum(2) = vperp * SIN(gyrophase)
       aligned_momentum(3) = current%part_p(3)
     ELSE
       aligned_momentum(1) = current%part_p(1)

--- a/epoch2d/src/user_interaction/helper.F90
+++ b/epoch2d/src/user_interaction/helper.F90
@@ -1045,6 +1045,7 @@ CONTAINS
 
     ! z is the dummy magnetic field direction
     IF (x_perp_y_ignored_z_para) THEN
+      gyrophase = golden_angle * ipart
       p_perp = current%part_p(1)
       aligned_momentum(1) = p_perp * COS(gyrophase)
       aligned_momentum(2) = p_perp * SIN(gyrophase)

--- a/epoch2d/src/user_interaction/helper.F90
+++ b/epoch2d/src/user_interaction/helper.F90
@@ -1037,7 +1037,7 @@ CONTAINS
     INTEGER(i8), INTENT(IN) :: ipart
     LOGICAL, INTENT(IN) :: x_perp_y_ignored_z_para
     REAL(num), DIMENSION(3,3) :: rotation_matrix
-    REAL(num) :: vperp, gyrophase
+    REAL(num) :: p_perp, gyrophase
     REAL(num), PARAMETER :: golden_angle = pi * (3.0_num - SQRT(5.0_num))
     REAL(num), DIMENSION(3) :: aligned_momentum
 
@@ -1045,9 +1045,9 @@ CONTAINS
 
     ! z is the dummy magnetic field direction
     IF (x_perp_y_ignored_z_para) THEN
-      vperp = current%part_p(1)
-      aligned_momentum(1) = vperp * COS(gyrophase)
-      aligned_momentum(2) = vperp * SIN(gyrophase)
+      p_perp = current%part_p(1)
+      aligned_momentum(1) = p_perp * COS(gyrophase)
+      aligned_momentum(2) = p_perp * SIN(gyrophase)
       aligned_momentum(3) = current%part_p(3)
     ELSE
       aligned_momentum(1) = current%part_p(1)

--- a/epoch2d/src/user_interaction/helper.F90
+++ b/epoch2d/src/user_interaction/helper.F90
@@ -1037,7 +1037,7 @@ CONTAINS
     INTEGER(i8), INTENT(IN) :: ipart
     LOGICAL, INTENT(IN) :: x_perp_y_ignored_z_para
     REAL(num), DIMENSION(3,3) :: rotation_matrix
-    REAL(num) :: gyrophase
+    REAL(num) :: vperp, gyrophase
     REAL(num), PARAMETER :: golden_angle = pi * (3.0_num - SQRT(5.0_num))
     REAL(num), DIMENSION(3) :: aligned_momentum
 
@@ -1045,9 +1045,9 @@ CONTAINS
 
     ! z is the dummy magnetic field direction
     IF (x_perp_y_ignored_z_para) THEN
-      gyrophase = golden_angle * ipart
-      aligned_momentum(1) = current%part_p(1) * COS(gyrophase)
-      aligned_momentum(2) = current%part_p(1) * SIN(gyrophase)
+      vperp = current%part_p(1)
+      aligned_momentum(1) = vperp * COS(gyrophase)
+      aligned_momentum(2) = vperp * SIN(gyrophase)
       aligned_momentum(3) = current%part_p(3)
     ELSE
       aligned_momentum(1) = current%part_p(1)

--- a/epoch3d/src/user_interaction/helper.F90
+++ b/epoch3d/src/user_interaction/helper.F90
@@ -1120,7 +1120,7 @@ CONTAINS
     INTEGER(i8), INTENT(IN) :: ipart
     LOGICAL, INTENT(IN) :: x_perp_y_ignored_z_para
     REAL(num), DIMENSION(3,3) :: rotation_matrix
-    REAL(num) :: vperp, gyrophase
+    REAL(num) :: p_perp, gyrophase
     REAL(num), PARAMETER :: golden_angle = pi * (3.0_num - SQRT(5.0_num))
     REAL(num), DIMENSION(3) :: aligned_momentum
 
@@ -1129,9 +1129,9 @@ CONTAINS
     ! z is the dummy magnetic field direction
     IF (x_perp_y_ignored_z_para) THEN
       gyrophase = golden_angle * ipart
-      vperp = current%part_p(1)
-      aligned_momentum(1) = vperp * COS(gyrophase)
-      aligned_momentum(2) = vperp * SIN(gyrophase)
+      p_perp = current%part_p(1)
+      aligned_momentum(1) = p_perp * COS(gyrophase)
+      aligned_momentum(2) = p_perp * SIN(gyrophase)
       aligned_momentum(3) = current%part_p(3)
     ELSE
       aligned_momentum(1) = current%part_p(1)

--- a/epoch3d/src/user_interaction/helper.F90
+++ b/epoch3d/src/user_interaction/helper.F90
@@ -1120,7 +1120,7 @@ CONTAINS
     INTEGER(i8), INTENT(IN) :: ipart
     LOGICAL, INTENT(IN) :: x_perp_y_ignored_z_para
     REAL(num), DIMENSION(3,3) :: rotation_matrix
-    REAL(num) :: gyrophase
+    REAL(num) :: vperp, gyrophase
     REAL(num), PARAMETER :: golden_angle = pi * (3.0_num - SQRT(5.0_num))
     REAL(num), DIMENSION(3) :: aligned_momentum
 
@@ -1129,8 +1129,9 @@ CONTAINS
     ! z is the dummy magnetic field direction
     IF (x_perp_y_ignored_z_para) THEN
       gyrophase = golden_angle * ipart
-      aligned_momentum(1) = current%part_p(1) * COS(gyrophase)
-      aligned_momentum(2) = current%part_p(1) * SIN(gyrophase)
+      vperp = current%part_p(1)
+      aligned_momentum(1) = vperp * COS(gyrophase)
+      aligned_momentum(2) = vperp * SIN(gyrophase)
       aligned_momentum(3) = current%part_p(3)
     ELSE
       aligned_momentum(1) = current%part_p(1)


### PR DESCRIPTION
When using `x_perp_y_ignored_z_parallel` it is necessary to treat the `px` values as perpendicular velocities, which are then projected into `(px, py)` via an angle. What existed was:

```
vector(1) = vector(1) * COS(angle)
vector(2) = vector(1) * SIN(angle)
```

but I didn't intend `vector(2) == vector(1) * COS(angle) * SIN(angle)`. This PR changes it to what I really wanted:

```
radius = vector(1)
vector(1) = radius * COS(angle)
vector(2) = radius * SIN(angle)
```