### PR TITLE
Fixed initialisation of work_done_integrated (issue 364)

### DIFF
--- a/epoch1d/src/housekeeping/partlist.F90
+++ b/epoch1d/src/housekeeping/partlist.F90
@@ -605,6 +605,14 @@ CONTAINS
 #ifdef PROBE_TIME
     new_particle%probe_time = 0.0_num
 #endif
+#ifdef WORK_DONE_INTEGRATED
+    new_particle%work_x = 0_num
+    new_particle%work_y = 0_num
+    new_particle%work_z = 0_num
+    new_particle%work_x_total = 0_num
+    new_particle%work_y_total = 0_num
+    new_particle%work_z_total = 0_num
+#endif 
 
   END SUBROUTINE init_particle
 

--- a/epoch2d/src/housekeeping/partlist.F90
+++ b/epoch2d/src/housekeeping/partlist.F90
@@ -605,6 +605,14 @@ CONTAINS
 #ifdef PROBE_TIME
     new_particle%probe_time = 0.0_num
 #endif
+#ifdef WORK_DONE_INTEGRATED
+    new_particle%work_x = 0_num
+    new_particle%work_y = 0_num
+    new_particle%work_z = 0_num
+    new_particle%work_x_total = 0_num
+    new_particle%work_y_total = 0_num
+    new_particle%work_z_total = 0_num
+#endif 
 
   END SUBROUTINE init_particle
 

--- a/epoch3d/src/housekeeping/partlist.F90
+++ b/epoch3d/src/housekeeping/partlist.F90
@@ -605,6 +605,14 @@ CONTAINS
 #ifdef PROBE_TIME
     new_particle%probe_time = 0.0_num
 #endif
+#ifdef WORK_DONE_INTEGRATED
+    new_particle%work_x = 0_num
+    new_particle%work_y = 0_num
+    new_particle%work_z = 0_num
+    new_particle%work_x_total = 0_num
+    new_particle%work_y_total = 0_num
+    new_particle%work_z_total = 0_num
+#endif 
 
   END SUBROUTINE init_particle
 


### PR DESCRIPTION
Previously the particle variables `work_x`, `work_y`, `work_z`, `work_x_total`, `work_y_total`, `work_z_total` were not properly initialised to 0. This caused them to have unpredictable behaviour, with some values tending towards numerically high unphysical values. This fix was provided in issue 364.