### PR TITLE
Collisional ionisation secondary lists bug fix

### DIFF
--- a/epoch1d/src/deck/deck_collision_block.F90
+++ b/epoch1d/src/deck/deck_collision_block.F90
@@ -88,11 +88,29 @@ CONTAINS
         END DO
       END DO
 
-      ! Identify which species need secondary lists for collisional ionisation
+      ! Identify species to make secondary lists for in collisional ionisation
       IF (use_collisional_ionisation) THEN
+        ! Tag all release species as electrons (required for 
+        ! unique_electron_species)
+        DO i = 1, n_species
+          IF (species_list(i)%ionise) THEN 
+            species_list(species_list(i)%release_species)%electron = .TRUE. 
+          END IF 
+        END DO 
+
+        ! Make secondary lists for ionising particles, and electrons
         DO i = 1, n_species
           IF (species_list(i)%ionise .OR. species_list(i)%electron) THEN
             species_list(i)%make_secondary_list = .TRUE.
+          END IF
+        END DO
+
+        ! Secondary lists also needed for the final ionisation state, which does 
+        ! not ionise, as ionised ions are written to this list
+        DO i = 1, n_species 
+          IF (species_list(i)%ionise) THEN 
+            species_list( &
+                species_list(i)%ionise_to_species)%make_secondary_list = .TRUE.
           END IF
         END DO
       END IF

--- a/epoch2d/.vscode/settings.json
+++ b/epoch2d/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "fortran.fortls.disabled": true
+}

--- a/epoch2d/.vscode/settings.json
+++ b/epoch2d/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "fortran.fortls.disabled": true
-}

--- a/epoch2d/src/deck/deck_collision_block.F90
+++ b/epoch2d/src/deck/deck_collision_block.F90
@@ -88,11 +88,29 @@ CONTAINS
         END DO
       END DO
 
-      ! Identify which species need secondary lists for collisional ionisation
+      ! Identify species to make secondary lists for in collisional ionisation
       IF (use_collisional_ionisation) THEN
+        ! Tag all release species as electrons (required for 
+        ! unique_electron_species)
+        DO i = 1, n_species
+          IF (species_list(i)%ionise) THEN 
+            species_list(species_list(i)%release_species)%electron = .TRUE. 
+          END IF 
+        END DO 
+
+        ! Make secondary lists for ionising particles, and electrons
         DO i = 1, n_species
           IF (species_list(i)%ionise .OR. species_list(i)%electron) THEN
             species_list(i)%make_secondary_list = .TRUE.
+          END IF
+        END DO
+
+        ! Secondary lists also needed for the final ionisation state, which does 
+        ! not ionise, as ionised ions are written to this list
+        DO i = 1, n_species 
+          IF (species_list(i)%ionise) THEN 
+            species_list( &
+                species_list(i)%ionise_to_species)%make_secondary_list = .TRUE.
           END IF
         END DO
       END IF

--- a/epoch3d/src/deck/deck_collision_block.F90
+++ b/epoch3d/src/deck/deck_collision_block.F90
@@ -88,11 +88,29 @@ CONTAINS
         END DO
       END DO
 
-      ! Identify which species need secondary lists for collisional ionisation
+      ! Identify species to make secondary lists for in collisional ionisation
       IF (use_collisional_ionisation) THEN
+        ! Tag all release species as electrons (required for 
+        ! unique_electron_species)
+        DO i = 1, n_species
+          IF (species_list(i)%ionise) THEN 
+            species_list(species_list(i)%release_species)%electron = .TRUE. 
+          END IF 
+        END DO 
+
+        ! Make secondary lists for ionising particles, and electrons
         DO i = 1, n_species
           IF (species_list(i)%ionise .OR. species_list(i)%electron) THEN
             species_list(i)%make_secondary_list = .TRUE.
+          END IF
+        END DO
+
+        ! Secondary lists also needed for the final ionisation state, which does 
+        ! not ionise, as ionised ions are written to this list
+        DO i = 1, n_species 
+          IF (species_list(i)%ionise) THEN 
+            species_list( &
+                species_list(i)%ionise_to_species)%make_secondary_list = .TRUE.
           END IF
         END DO
       END IF


### PR DESCRIPTION
In version 4.18, EPOCH created secondary lists for all particle species, each step - even if the particle species wasn't involved in collisions or collisional ionisation. In 4.19, this was changed so that only colliding or ionising species were given secondary lists, on steps where collisions or collisional ionisation was calculated. This was controlled with the `species_list` variable: `make_secondary_lists`. However, there was a bug where secondary lists were not written for:
- Electron release species
- The final, non-ionisng ion species

Furthermore, when using the `unique_electron_species` flag to automatically generate unique electron release species, these electrons were not given the `electron` status, and were not included in collisional ionisation.

This bug fix now correctly labels all particle species involved in collisional ionisation, and writes secondary lists where appropriate.

This bug was first identified in a private message to me, by Jiangsai at Peking University.