### PR TITLE
Made integrated work done a restart variable (Issue 452)

### DIFF
--- a/epoch1d/src/deck/deck_io_block.F90
+++ b/epoch1d/src/deck/deck_io_block.F90
@@ -1099,6 +1099,14 @@ CONTAINS
     io_block%dumpmask(c_dump_part_id) = &
         IOR(io_block%dumpmask(c_dump_part_id), c_io_restartable)
 #endif
+#ifdef WORK_DONE_INTEGRATED
+    io_block%dumpmask(c_dump_part_work_x_total) = &
+         IOR(io_block%dumpmask(c_dump_part_work_x_total), c_io_restartable)
+    io_block%dumpmask(c_dump_part_work_y_total) = &
+         IOR(io_block%dumpmask(c_dump_part_work_y_total), c_io_restartable)
+    io_block%dumpmask(c_dump_part_work_z_total) = &
+         IOR(io_block%dumpmask(c_dump_part_work_z_total), c_io_restartable)
+#endif   
     ! Persistent IDs
     io_block%dumpmask(c_dump_persistent_ids) = &
         IOR(io_block%dumpmask(c_dump_persistent_ids), c_io_restartable)

--- a/epoch1d/src/housekeeping/setup.F90
+++ b/epoch1d/src/housekeeping/setup.F90
@@ -1312,6 +1312,46 @@ CONTAINS
           CALL abort_code(c_err_pp_options_missing)
           STOP
 #endif
+        
+        ELSE IF (block_id(1:23) == 'time_integrated_work_x/') THEN
+#ifdef WORK_DONE_INTEGRATED
+          CALL sdf_read_point_variable(sdf_handle, npart_local, &
+              species_subtypes(ispecies), it_work_x_total)
+#else
+          IF (rank == 0) THEN
+            PRINT*, '*** ERROR ***'
+            PRINT*, 'Cannot load dump file with time integrated work.'
+            PRINT*, 'Please recompile with the -DWORK_DONE_INTEGRATED option.'
+          END IF
+          CALL abort_code(c_err_pp_options_missing)
+          STOP
+#endif
+          ELSE IF (block_id(1:23) == 'time_integrated_work_y/') THEN
+#ifdef WORK_DONE_INTEGRATED
+          CALL sdf_read_point_variable(sdf_handle, npart_local, &
+              species_subtypes(ispecies), it_work_y_total)
+#else
+          IF (rank == 0) THEN
+            PRINT*, '*** ERROR ***'
+            PRINT*, 'Cannot load dump file with time integrated work.'
+            PRINT*, 'Please recompile with the -DWORK_DONE_INTEGRATED option.'
+          END IF
+          CALL abort_code(c_err_pp_options_missing)
+          STOP
+#endif
+          ELSE IF (block_id(1:23) == 'time_integrated_work_z/') THEN
+#ifdef WORK_DONE_INTEGRATED
+          CALL sdf_read_point_variable(sdf_handle, npart_local, &
+              species_subtypes(ispecies), it_work_z_total)
+#else
+          IF (rank == 0) THEN
+            PRINT*, '*** ERROR ***'
+            PRINT*, 'Cannot load dump file with time integrated work.'
+            PRINT*, 'Please recompile with the -DWORK_DONE_INTEGRATED option.'
+          END IF
+          CALL abort_code(c_err_pp_options_missing)
+          STOP
+#endif
         END IF
       END SELECT
     END DO
@@ -1785,6 +1825,68 @@ CONTAINS
     it_optical_depth_bremsstrahlung = 0
 
   END FUNCTION it_optical_depth_bremsstrahlung
+#endif
+
+
+
+#ifdef WORK_DONE_INTEGRATED
+  FUNCTION it_work_x_total(array, npart_this_it, start, param)
+
+    REAL(num) :: it_work_x_total
+    REAL(num), DIMENSION(:), INTENT(IN) :: array
+    INTEGER, INTENT(INOUT) :: npart_this_it
+    LOGICAL, INTENT(IN) :: start
+    INTEGER, INTENT(IN), OPTIONAL :: param
+    INTEGER :: ipart
+
+    DO ipart = 1, npart_this_it
+      iterator_list%work_x_total = array(ipart)
+      iterator_list => iterator_list%next
+    END DO
+
+    it_work_x_total = 0
+
+  END FUNCTION it_work_x_total
+
+
+
+  FUNCTION it_work_y_total(array, npart_this_it, start, param)
+
+    REAL(num) :: it_work_y_total
+    REAL(num), DIMENSION(:), INTENT(IN) :: array
+    INTEGER, INTENT(INOUT) :: npart_this_it
+    LOGICAL, INTENT(IN) :: start
+    INTEGER, INTENT(IN), OPTIONAL :: param
+    INTEGER :: ipart
+
+    DO ipart = 1, npart_this_it
+      iterator_list%work_y_total = array(ipart)
+      iterator_list => iterator_list%next
+    END DO
+
+    it_work_y_total = 0
+
+  END FUNCTION it_work_y_total
+
+
+  
+  FUNCTION it_work_z_total(array, npart_this_it, start, param)
+
+    REAL(num) :: it_work_z_total
+    REAL(num), DIMENSION(:), INTENT(IN) :: array
+    INTEGER, INTENT(INOUT) :: npart_this_it
+    LOGICAL, INTENT(IN) :: start
+    INTEGER, INTENT(IN), OPTIONAL :: param
+    INTEGER :: ipart
+
+    DO ipart = 1, npart_this_it
+      iterator_list%work_z_total = array(ipart)
+      iterator_list => iterator_list%next
+    END DO
+
+    it_work_z_total = 0
+
+  END FUNCTION it_work_z_total  
 #endif
 
 

--- a/epoch2d/.vscode/settings.json
+++ b/epoch2d/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "fortran.fortls.disabled": true
-}

--- a/epoch2d/src/deck/deck_io_block.F90
+++ b/epoch2d/src/deck/deck_io_block.F90
@@ -1112,6 +1112,14 @@ CONTAINS
     io_block%dumpmask(c_dump_part_id) = &
         IOR(io_block%dumpmask(c_dump_part_id), c_io_restartable)
 #endif
+#ifdef WORK_DONE_INTEGRATED
+    io_block%dumpmask(c_dump_part_work_x_total) = &
+         IOR(io_block%dumpmask(c_dump_part_work_x_total), c_io_restartable)
+    io_block%dumpmask(c_dump_part_work_y_total) = &
+         IOR(io_block%dumpmask(c_dump_part_work_y_total), c_io_restartable)
+    io_block%dumpmask(c_dump_part_work_z_total) = &
+         IOR(io_block%dumpmask(c_dump_part_work_z_total), c_io_restartable)
+#endif   
     ! Persistent IDs
     io_block%dumpmask(c_dump_persistent_ids) = &
         IOR(io_block%dumpmask(c_dump_persistent_ids), c_io_restartable)

--- a/epoch2d/src/housekeeping/setup.F90
+++ b/epoch2d/src/housekeeping/setup.F90
@@ -1405,6 +1405,46 @@ CONTAINS
           CALL abort_code(c_err_pp_options_missing)
           STOP
 #endif
+        
+        ELSE IF (block_id(1:23) == 'time_integrated_work_x/') THEN
+#ifdef WORK_DONE_INTEGRATED
+          CALL sdf_read_point_variable(sdf_handle, npart_local, &
+              species_subtypes(ispecies), it_work_x_total)
+#else
+          IF (rank == 0) THEN
+            PRINT*, '*** ERROR ***'
+            PRINT*, 'Cannot load dump file with time integrated work.'
+            PRINT*, 'Please recompile with the -DWORK_DONE_INTEGRATED option.'
+          END IF
+          CALL abort_code(c_err_pp_options_missing)
+          STOP
+#endif
+          ELSE IF (block_id(1:23) == 'time_integrated_work_y/') THEN
+#ifdef WORK_DONE_INTEGRATED
+          CALL sdf_read_point_variable(sdf_handle, npart_local, &
+              species_subtypes(ispecies), it_work_y_total)
+#else
+          IF (rank == 0) THEN
+            PRINT*, '*** ERROR ***'
+            PRINT*, 'Cannot load dump file with time integrated work.'
+            PRINT*, 'Please recompile with the -DWORK_DONE_INTEGRATED option.'
+          END IF
+          CALL abort_code(c_err_pp_options_missing)
+          STOP
+#endif
+          ELSE IF (block_id(1:23) == 'time_integrated_work_z/') THEN
+#ifdef WORK_DONE_INTEGRATED
+          CALL sdf_read_point_variable(sdf_handle, npart_local, &
+              species_subtypes(ispecies), it_work_z_total)
+#else
+          IF (rank == 0) THEN
+            PRINT*, '*** ERROR ***'
+            PRINT*, 'Cannot load dump file with time integrated work.'
+            PRINT*, 'Please recompile with the -DWORK_DONE_INTEGRATED option.'
+          END IF
+          CALL abort_code(c_err_pp_options_missing)
+          STOP
+#endif
         END IF
       END SELECT
     END DO
@@ -1891,6 +1931,68 @@ CONTAINS
     it_optical_depth_bremsstrahlung = 0
 
   END FUNCTION it_optical_depth_bremsstrahlung
+#endif
+
+
+
+#ifdef WORK_DONE_INTEGRATED
+  FUNCTION it_work_x_total(array, npart_this_it, start, param)
+
+    REAL(num) :: it_work_x_total
+    REAL(num), DIMENSION(:), INTENT(IN) :: array
+    INTEGER, INTENT(INOUT) :: npart_this_it
+    LOGICAL, INTENT(IN) :: start
+    INTEGER, INTENT(IN), OPTIONAL :: param
+    INTEGER :: ipart
+
+    DO ipart = 1, npart_this_it
+      iterator_list%work_x_total = array(ipart)
+      iterator_list => iterator_list%next
+    END DO
+
+    it_work_x_total = 0
+
+  END FUNCTION it_work_x_total
+
+
+
+  FUNCTION it_work_y_total(array, npart_this_it, start, param)
+
+    REAL(num) :: it_work_y_total
+    REAL(num), DIMENSION(:), INTENT(IN) :: array
+    INTEGER, INTENT(INOUT) :: npart_this_it
+    LOGICAL, INTENT(IN) :: start
+    INTEGER, INTENT(IN), OPTIONAL :: param
+    INTEGER :: ipart
+
+    DO ipart = 1, npart_this_it
+      iterator_list%work_y_total = array(ipart)
+      iterator_list => iterator_list%next
+    END DO
+
+    it_work_y_total = 0
+
+  END FUNCTION it_work_y_total
+
+
+  
+  FUNCTION it_work_z_total(array, npart_this_it, start, param)
+
+    REAL(num) :: it_work_z_total
+    REAL(num), DIMENSION(:), INTENT(IN) :: array
+    INTEGER, INTENT(INOUT) :: npart_this_it
+    LOGICAL, INTENT(IN) :: start
+    INTEGER, INTENT(IN), OPTIONAL :: param
+    INTEGER :: ipart
+
+    DO ipart = 1, npart_this_it
+      iterator_list%work_z_total = array(ipart)
+      iterator_list => iterator_list%next
+    END DO
+
+    it_work_z_total = 0
+
+  END FUNCTION it_work_z_total  
 #endif
 
 

--- a/epoch3d/src/deck/deck_io_block.F90
+++ b/epoch3d/src/deck/deck_io_block.F90
@@ -1124,6 +1124,14 @@ CONTAINS
     io_block%dumpmask(c_dump_part_id) = &
         IOR(io_block%dumpmask(c_dump_part_id), c_io_restartable)
 #endif
+#ifdef WORK_DONE_INTEGRATED
+    io_block%dumpmask(c_dump_part_work_x_total) = &
+         IOR(io_block%dumpmask(c_dump_part_work_x_total), c_io_restartable)
+    io_block%dumpmask(c_dump_part_work_y_total) = &
+         IOR(io_block%dumpmask(c_dump_part_work_y_total), c_io_restartable)
+    io_block%dumpmask(c_dump_part_work_z_total) = &
+         IOR(io_block%dumpmask(c_dump_part_work_z_total), c_io_restartable)
+#endif   
     ! Persistent IDs
     io_block%dumpmask(c_dump_persistent_ids) = &
         IOR(io_block%dumpmask(c_dump_persistent_ids), c_io_restartable)

--- a/epoch3d/src/housekeeping/setup.F90
+++ b/epoch3d/src/housekeeping/setup.F90
@@ -1506,6 +1506,46 @@ CONTAINS
           CALL abort_code(c_err_pp_options_missing)
           STOP
 #endif
+
+        ELSE IF (block_id(1:23) == 'time_integrated_work_x/') THEN
+#ifdef WORK_DONE_INTEGRATED
+          CALL sdf_read_point_variable(sdf_handle, npart_local, &
+              species_subtypes(ispecies), it_work_x_total)
+#else
+          IF (rank == 0) THEN
+            PRINT*, '*** ERROR ***'
+            PRINT*, 'Cannot load dump file with time integrated work.'
+            PRINT*, 'Please recompile with the -DWORK_DONE_INTEGRATED option.'
+          END IF
+          CALL abort_code(c_err_pp_options_missing)
+          STOP
+#endif
+          ELSE IF (block_id(1:23) == 'time_integrated_work_y/') THEN
+#ifdef WORK_DONE_INTEGRATED
+          CALL sdf_read_point_variable(sdf_handle, npart_local, &
+              species_subtypes(ispecies), it_work_y_total)
+#else
+          IF (rank == 0) THEN
+            PRINT*, '*** ERROR ***'
+            PRINT*, 'Cannot load dump file with time integrated work.'
+            PRINT*, 'Please recompile with the -DWORK_DONE_INTEGRATED option.'
+          END IF
+          CALL abort_code(c_err_pp_options_missing)
+          STOP
+#endif
+          ELSE IF (block_id(1:23) == 'time_integrated_work_z/') THEN
+#ifdef WORK_DONE_INTEGRATED
+          CALL sdf_read_point_variable(sdf_handle, npart_local, &
+              species_subtypes(ispecies), it_work_z_total)
+#else
+          IF (rank == 0) THEN
+            PRINT*, '*** ERROR ***'
+            PRINT*, 'Cannot load dump file with time integrated work.'
+            PRINT*, 'Please recompile with the -DWORK_DONE_INTEGRATED option.'
+          END IF
+          CALL abort_code(c_err_pp_options_missing)
+          STOP
+#endif
         END IF
       END SELECT
     END DO
@@ -2000,6 +2040,68 @@ CONTAINS
     it_optical_depth_bremsstrahlung = 0
 
   END FUNCTION it_optical_depth_bremsstrahlung
+#endif
+
+
+
+#ifdef WORK_DONE_INTEGRATED
+  FUNCTION it_work_x_total(array, npart_this_it, start, param)
+
+    REAL(num) :: it_work_x_total
+    REAL(num), DIMENSION(:), INTENT(IN) :: array
+    INTEGER, INTENT(INOUT) :: npart_this_it
+    LOGICAL, INTENT(IN) :: start
+    INTEGER, INTENT(IN), OPTIONAL :: param
+    INTEGER :: ipart
+
+    DO ipart = 1, npart_this_it
+      iterator_list%work_x_total = array(ipart)
+      iterator_list => iterator_list%next
+    END DO
+
+    it_work_x_total = 0
+
+  END FUNCTION it_work_x_total
+
+
+
+  FUNCTION it_work_y_total(array, npart_this_it, start, param)
+
+    REAL(num) :: it_work_y_total
+    REAL(num), DIMENSION(:), INTENT(IN) :: array
+    INTEGER, INTENT(INOUT) :: npart_this_it
+    LOGICAL, INTENT(IN) :: start
+    INTEGER, INTENT(IN), OPTIONAL :: param
+    INTEGER :: ipart
+
+    DO ipart = 1, npart_this_it
+      iterator_list%work_y_total = array(ipart)
+      iterator_list => iterator_list%next
+    END DO
+
+    it_work_y_total = 0
+
+  END FUNCTION it_work_y_total
+
+
+  
+  FUNCTION it_work_z_total(array, npart_this_it, start, param)
+
+    REAL(num) :: it_work_z_total
+    REAL(num), DIMENSION(:), INTENT(IN) :: array
+    INTEGER, INTENT(INOUT) :: npart_this_it
+    LOGICAL, INTENT(IN) :: start
+    INTEGER, INTENT(IN), OPTIONAL :: param
+    INTEGER :: ipart
+
+    DO ipart = 1, npart_this_it
+      iterator_list%work_z_total = array(ipart)
+      iterator_list => iterator_list%next
+    END DO
+
+    it_work_z_total = 0
+
+  END FUNCTION it_work_z_total  
 #endif
 
 


### PR DESCRIPTION
When the code is compiled with `-DWORK_DONE_INTEGRATED`, 6 new particle variables are added to the simulation. Three of these track the work done on the particle (in $x$, $y$, and $z$) by fields in the most recent step, and the other three track the total work done on the particle over the simulation.

Issue 452 highlighted the fact that total work done was reset upon code restart, and the author provided code to make these restart variables when the code is compiled with `-DWORK_DONE_INTEGRATED`. Their code has been implemented and tested, and EPOCH now correctly sets the variables `work_x_total`, `work_y_total` and `work_z_total` for each particle on restart.