### PR TITLE
Fixed issue 431 - subsets can now generate particle ID for ID filtering

### DIFF
--- a/epoch1d/src/io/diagnostics.F90
+++ b/epoch1d/src/io/diagnostics.F90
@@ -2358,6 +2358,13 @@ CONTAINS
     IF (done_subset_init) RETURN
     done_subset_init = .TRUE.
 
+    ! Update particle ID values if using
+#if defined(PARTICLE_ID) || defined(PARTICLE_ID4)
+    DO i = 1, n_species 
+      CALL generate_particle_ids(species_list(i)%attached_list)
+    END DO
+#endif
+
     IF (isubset == 1) THEN
       io_list => species_list
       RETURN

--- a/epoch2d/src/io/diagnostics.F90
+++ b/epoch2d/src/io/diagnostics.F90
@@ -2419,6 +2419,13 @@ CONTAINS
     IF (done_subset_init) RETURN
     done_subset_init = .TRUE.
 
+    ! Update particle ID values if using
+#if defined(PARTICLE_ID) || defined(PARTICLE_ID4)
+    DO i = 1, n_species 
+      CALL generate_particle_ids(species_list(i)%attached_list)
+    END DO
+#endif
+
     IF (isubset == 1) THEN
       io_list => species_list
       RETURN

--- a/epoch3d/src/io/diagnostics.F90
+++ b/epoch3d/src/io/diagnostics.F90
@@ -2475,6 +2475,13 @@ CONTAINS
     IF (done_subset_init) RETURN
     done_subset_init = .TRUE.
 
+    ! Update particle ID values if using
+#if defined(PARTICLE_ID) || defined(PARTICLE_ID4)
+    DO i = 1, n_species 
+      CALL generate_particle_ids(species_list(i)%attached_list)
+    END DO
+#endif
+
     IF (isubset == 1) THEN
       io_list => species_list
       RETURN


### PR DESCRIPTION
EPOCH has a `subset` block for reduced particle output. The user can use subsets to only output particles which fulfil certain criteria. When the code is compiled with `-DPARTICLE_ID` or `-DPARTICLE_ID4`, the user can set minimum and maximum ID values using `id_min` and `id_max`. However, the subset features in EPOCH were not capable of generating their own particle IDs, so the user would need another ID diagnostic before particles were assigned ID for subset filtering.

Now subsets run the ID generation script when called (provided the code is compiled with any particle ID capability). This allows subsets to use ID filtering without any other ID diagnostic present, resolving the problem raised in issue 431.