### PR TITLE
Fixed bug with multiple subset maps (issue 361)

### DIFF
--- a/epoch1d/src/housekeeping/particle_id_hash.F90
+++ b/epoch1d/src/housekeeping/particle_id_hash.F90
@@ -657,7 +657,7 @@ CONTAINS
     shifthash = hashmap
     DO ihash = 1, sz
       IF (IAND(shifthash, 1_i8) /= 0_i8) &
-          CALL pid_hash_add_hkind(this%list(ihash)%contents, new_id)
+          CALL pid_hash_add_hkind(this%list(sz + 1 - ihash)%contents, new_id)
       shifthash = ISHFT(shifthash, -1_i8)
     END DO
 

--- a/epoch2d/src/housekeeping/particle_id_hash.F90
+++ b/epoch2d/src/housekeeping/particle_id_hash.F90
@@ -657,7 +657,7 @@ CONTAINS
     shifthash = hashmap
     DO ihash = 1, sz
       IF (IAND(shifthash, 1_i8) /= 0_i8) &
-          CALL pid_hash_add_hkind(this%list(ihash)%contents, new_id)
+          CALL pid_hash_add_hkind(this%list(sz + 1 - ihash)%contents, new_id)
       shifthash = ISHFT(shifthash, -1_i8)
     END DO
 

--- a/epoch3d/src/housekeeping/particle_id_hash.F90
+++ b/epoch3d/src/housekeeping/particle_id_hash.F90
@@ -657,7 +657,7 @@ CONTAINS
     shifthash = hashmap
     DO ihash = 1, sz
       IF (IAND(shifthash, 1_i8) /= 0_i8) &
-          CALL pid_hash_add_hkind(this%list(ihash)%contents, new_id)
+          CALL pid_hash_add_hkind(this%list(sz + 1 - ihash)%contents, new_id)
       shifthash = ISHFT(shifthash, -1_i8)
     END DO
 


### PR DESCRIPTION
When multiple persistent subsets describe the same species (but different particles), there was an issue when particles moved between processors. Each processor only knows which of its local particles are in subsets, so subset tagging information must be transferred along with particles when they move into cells on different ranks. This is achieved using the `hashmap` integer.

The `hashmap` integer is written such that in its binary representation, each subset represents a different digit - and this is 1 or 0 if the subset does or doesn't contain the particle (respectively). Hence, if a particle was associated with subsets 1, 4 and 5, but not with 2 or 3, its `hashmap` would be 35, or 10011 in binary representation.

However, when loading the new processor with the subset information, the `pidr_add_with_map` subroutine would read this in reverse, assuming subsets 1, 2 and 5 containted the particle instead of 1, 4 and 5. Hence, when multiple persistent subsets were used on the same species, particles would be moved between persistent subsets. This fix reverses the order of the `pidr_add_with_map` reader, such that the map is read correctly.