### PR TITLE
Bug fix: photon energy extrapolation

### DIFF
--- a/epoch1d/src/physics_packages/photons.F90
+++ b/epoch1d/src/physics_packages/photons.F90
@@ -916,7 +916,7 @@ CONTAINS
 
     REAL(num) :: calculate_photon_energy
     REAL(num), INTENT(IN) :: rand_seed, eta, generating_gamma
-    REAL(num) :: eta_min, chi_final
+    REAL(num) :: eta_min, chi_tmp, chi_final
 
     eta_min = 10.0_num**MINVAL(log_eta)
     IF (eta < eta_min) THEN ! Extrapolate downwards with chi \propto eta^2

--- a/epoch1d/src/physics_packages/photons.F90
+++ b/epoch1d/src/physics_packages/photons.F90
@@ -916,7 +916,7 @@ CONTAINS
 
     REAL(num) :: calculate_photon_energy
     REAL(num), INTENT(IN) :: rand_seed, eta, generating_gamma
-    REAL(num) :: chi_final
+    REAL(num) :: eta_min, chi_final
 
     eta_min = 10.0_num**MINVAL(log_eta)
     IF (eta < eta_min) THEN ! Extrapolate downwards with chi \propto eta^2

--- a/epoch1d/src/physics_packages/photons.F90
+++ b/epoch1d/src/physics_packages/photons.F90
@@ -918,8 +918,15 @@ CONTAINS
     REAL(num), INTENT(IN) :: rand_seed, eta, generating_gamma
     REAL(num) :: chi_final
 
-    chi_final = find_value_from_table_alt(eta, rand_seed, &
-        n_sample_eta, n_sample_chi, log_eta, log_chi, p_photon_energy)
+    eta_min = 10.0_num**MINVAL(log_eta)
+    IF (eta < eta_min) THEN ! Extrapolate downwards with chi \propto eta^2
+      chi_tmp = find_value_from_table_alt(eta_min, rand_seed, &
+          n_sample_eta, n_sample_chi, log_eta, log_chi, p_photon_energy)
+      chi_final = chi_tmp * (eta / eta_min)**2
+    ELSE
+      chi_final = find_value_from_table_alt(eta, rand_seed, &
+          n_sample_eta, n_sample_chi, log_eta, log_chi, p_photon_energy)
+    ENDIF
 
     calculate_photon_energy = (2.0_num * chi_final / eta) * generating_gamma &
         * m0 * c**2

--- a/epoch2d/src/physics_packages/photons.F90
+++ b/epoch2d/src/physics_packages/photons.F90
@@ -929,7 +929,7 @@ CONTAINS
 
     REAL(num) :: calculate_photon_energy
     REAL(num), INTENT(IN) :: rand_seed, eta, generating_gamma
-    REAL(num) :: chi_final
+    REAL(num) :: eta_min, chi_final
 
     eta_min = 10.0_num**MINVAL(log_eta)
     IF (eta < eta_min) THEN ! Extrapolate downwards with chi \propto eta^2

--- a/epoch2d/src/physics_packages/photons.F90
+++ b/epoch2d/src/physics_packages/photons.F90
@@ -931,8 +931,15 @@ CONTAINS
     REAL(num), INTENT(IN) :: rand_seed, eta, generating_gamma
     REAL(num) :: chi_final
 
-    chi_final = find_value_from_table_alt(eta, rand_seed, &
-        n_sample_eta, n_sample_chi, log_eta, log_chi, p_photon_energy)
+    eta_min = 10.0_num**MINVAL(log_eta)
+    IF (eta < eta_min) THEN ! Extrapolate downwards with chi \propto eta^2
+      chi_tmp = find_value_from_table_alt(eta_min, rand_seed, &
+          n_sample_eta, n_sample_chi, log_eta, log_chi, p_photon_energy)
+      chi_final = chi_tmp * (eta / eta_min)**2
+    ELSE
+      chi_final = find_value_from_table_alt(eta, rand_seed, &
+          n_sample_eta, n_sample_chi, log_eta, log_chi, p_photon_energy)
+    ENDIF
 
     calculate_photon_energy = (2.0_num * chi_final / eta) * generating_gamma &
         * m0 * c**2

--- a/epoch2d/src/physics_packages/photons.F90
+++ b/epoch2d/src/physics_packages/photons.F90
@@ -929,7 +929,7 @@ CONTAINS
 
     REAL(num) :: calculate_photon_energy
     REAL(num), INTENT(IN) :: rand_seed, eta, generating_gamma
-    REAL(num) :: eta_min, chi_final
+    REAL(num) :: eta_min, chi_tmp, chi_final  
 
     eta_min = 10.0_num**MINVAL(log_eta)
     IF (eta < eta_min) THEN ! Extrapolate downwards with chi \propto eta^2

--- a/epoch3d/src/physics_packages/photons.F90
+++ b/epoch3d/src/physics_packages/photons.F90
@@ -944,8 +944,15 @@ CONTAINS
     REAL(num), INTENT(IN) :: rand_seed, eta, generating_gamma
     REAL(num) :: chi_final
 
-    chi_final = find_value_from_table_alt(eta, rand_seed, &
-        n_sample_eta, n_sample_chi, log_eta, log_chi, p_photon_energy)
+    eta_min = 10.0_num**MINVAL(log_eta)
+    IF (eta < eta_min) THEN ! Extrapolate downwards with chi \propto eta^2
+      chi_tmp = find_value_from_table_alt(eta_min, rand_seed, &
+          n_sample_eta, n_sample_chi, log_eta, log_chi, p_photon_energy)
+      chi_final = chi_tmp * (eta / eta_min)**2
+    ELSE
+      chi_final = find_value_from_table_alt(eta, rand_seed, &
+          n_sample_eta, n_sample_chi, log_eta, log_chi, p_photon_energy)
+    ENDIF
 
     calculate_photon_energy = (2.0_num * chi_final / eta) * generating_gamma &
         * m0 * c**2

--- a/epoch3d/src/physics_packages/photons.F90
+++ b/epoch3d/src/physics_packages/photons.F90
@@ -942,7 +942,7 @@ CONTAINS
 
     REAL(num) :: calculate_photon_energy
     REAL(num), INTENT(IN) :: rand_seed, eta, generating_gamma
-    REAL(num) :: eta_min, chi_final
+    REAL(num) :: eta_min, chi_tmp, chi_final  
 
     eta_min = 10.0_num**MINVAL(log_eta)
     IF (eta < eta_min) THEN ! Extrapolate downwards with chi \propto eta^2

--- a/epoch3d/src/physics_packages/photons.F90
+++ b/epoch3d/src/physics_packages/photons.F90
@@ -942,7 +942,7 @@ CONTAINS
 
     REAL(num) :: calculate_photon_energy
     REAL(num), INTENT(IN) :: rand_seed, eta, generating_gamma
-    REAL(num) :: chi_final
+    REAL(num) :: eta_min, chi_final
 
     eta_min = 10.0_num**MINVAL(log_eta)
     IF (eta < eta_min) THEN ! Extrapolate downwards with chi \propto eta^2


### PR DESCRIPTION
The calculate_photon_energy function in Photons.F90 draws the photon energy distribution from a look-up table in eta. If eta is below the bottom edge of the look-up table, this bug fix uses the low eta limit, where \chi \propto \eta^2, to extrapolate downards, calculating the correct photon energy.