### PR TITLE
Photon initialisation fix (issue #502)

### DIFF
--- a/epoch1d/src/physics_packages/injectors.F90
+++ b/epoch1d/src/physics_packages/injectors.F90
@@ -308,6 +308,13 @@ CONTAINS
       density = MIN(density, injector%density_max)
       new%weight = weight_fac * density
 #endif
+#if defined(PHOTONS) || defined(BREMSSTRAHLUNG)
+      ! For photons, assign additional variable used in photon particle-push
+      IF (species_list(injector%species)%species_type == c_species_id_photon) &
+          THEN 
+        new%particle_energy = SQRT(SUM(new%part_p**2)) * c
+      END IF
+#endif
       CALL add_particle_to_partlist(plist, new)
     END DO
 

--- a/epoch1d/src/user_interaction/helper.F90
+++ b/epoch1d/src/user_interaction/helper.F90
@@ -90,6 +90,7 @@ CONTAINS
 
     INTEGER :: ispecies, n
     TYPE(particle_species), POINTER :: species
+    TYPE(particle), POINTER :: current
     INTEGER :: i0, i1, iu, io
     TYPE(initial_condition_block), POINTER :: ic
 
@@ -141,6 +142,17 @@ CONTAINS
       ELSE IF (species%ic_df_type == c_ic_df_arbitrary) THEN
         CALL setup_particle_dist_fn(species, species_drift)
       END IF
+
+#if defined(PHOTONS) || defined(BREMSSTRAHLUNG)
+      ! For photons, assign additional variable used in photon particle-push
+      IF (species_list(ispecies)%species_type == c_species_id_photon) THEN 
+        current => species%attached_list%head 
+        DO WHILE (ASSOCIATED(current))
+          current%particle_energy = SQRT(SUM(current%part_p**2)) * c
+          current => current%next
+        END DO
+      END IF
+#endif
     END DO
 
     IF (pre_loading) RETURN

--- a/epoch1d/src/user_interaction/helper.F90
+++ b/epoch1d/src/user_interaction/helper.F90
@@ -90,9 +90,11 @@ CONTAINS
 
     INTEGER :: ispecies, n
     TYPE(particle_species), POINTER :: species
-    TYPE(particle), POINTER :: current
     INTEGER :: i0, i1, iu, io
     TYPE(initial_condition_block), POINTER :: ic
+#if defined(PHOTONS) || defined(BREMSSTRAHLUNG)
+    TYPE(particle), POINTER :: current
+#endif
 
     IF (pre_loading .AND. n_species > 0) THEN
       i0 = 1 - ng

--- a/epoch2d/src/physics_packages/injectors.F90
+++ b/epoch2d/src/physics_packages/injectors.F90
@@ -367,6 +367,13 @@ CONTAINS
         density = MIN(density, injector%density_max)
         new%weight = weight_fac * density
 #endif
+#if defined(PHOTONS) || defined(BREMSSTRAHLUNG)
+      ! For photons, assign additional variable used in photon particle-push
+      IF (species_list(injector%species)%species_type == c_species_id_photon) &
+          THEN 
+        new%particle_energy = SQRT(SUM(new%part_p**2)) * c
+      END IF
+#endif
         CALL add_particle_to_partlist(plist, new)
       END DO
     END DO

--- a/epoch2d/src/user_interaction/helper.F90
+++ b/epoch2d/src/user_interaction/helper.F90
@@ -96,9 +96,11 @@ CONTAINS
 
     INTEGER :: ispecies, n
     TYPE(particle_species), POINTER :: species
-    TYPE(particle), POINTER :: current
     INTEGER :: i0, i1, iu, io
     TYPE(initial_condition_block), POINTER :: ic
+#if defined(PHOTONS) || defined(BREMSSTRAHLUNG)
+    TYPE(particle), POINTER :: current
+#endif
 
     IF (pre_loading .AND. n_species > 0) THEN
       i0 = 1 - ng

--- a/epoch2d/src/user_interaction/helper.F90
+++ b/epoch2d/src/user_interaction/helper.F90
@@ -96,6 +96,7 @@ CONTAINS
 
     INTEGER :: ispecies, n
     TYPE(particle_species), POINTER :: species
+    TYPE(particle), POINTER :: current
     INTEGER :: i0, i1, iu, io
     TYPE(initial_condition_block), POINTER :: ic
 
@@ -147,6 +148,17 @@ CONTAINS
       ELSE IF (species%ic_df_type == c_ic_df_arbitrary) THEN
         CALL setup_particle_dist_fn(species, species_drift)
       END IF
+
+#if defined(PHOTONS) || defined(BREMSSTRAHLUNG)
+      ! For photons, assign additional variable used in photon particle-push
+      IF (species_list(ispecies)%species_type == c_species_id_photon) THEN 
+        current => species%attached_list%head 
+        DO WHILE (ASSOCIATED(current))
+          current%particle_energy = SQRT(SUM(current%part_p**2)) * c
+          current => current%next
+        END DO
+      END IF
+#endif
     END DO
 
     IF (pre_loading) RETURN

--- a/epoch3d/src/physics_packages/injectors.F90
+++ b/epoch3d/src/physics_packages/injectors.F90
@@ -404,6 +404,13 @@ CONTAINS
           density = MIN(density, injector%density_max)
           new%weight = weight_fac * density
 #endif
+#if defined(PHOTONS) || defined(BREMSSTRAHLUNG)
+      ! For photons, assign additional variable used in photon particle-push
+      IF (species_list(injector%species)%species_type == c_species_id_photon) &
+          THEN 
+        new%particle_energy = SQRT(SUM(new%part_p**2)) * c
+      END IF
+#endif
           CALL add_particle_to_partlist(plist, new)
         END DO
       END DO

--- a/epoch3d/src/user_interaction/helper.F90
+++ b/epoch3d/src/user_interaction/helper.F90
@@ -102,6 +102,7 @@ CONTAINS
 
     INTEGER :: ispecies, n
     TYPE(particle_species), POINTER :: species
+    TYPE(particle), POINTER :: current
     INTEGER :: i0, i1, iu, io
     TYPE(initial_condition_block), POINTER :: ic
 
@@ -153,6 +154,17 @@ CONTAINS
       ELSE IF (species%ic_df_type == c_ic_df_arbitrary) THEN
         CALL setup_particle_dist_fn(species, species_drift)
       END IF
+
+#if defined(PHOTONS) || defined(BREMSSTRAHLUNG)
+      ! For photons, assign additional variable used in photon particle-push
+      IF (species_list(ispecies)%species_type == c_species_id_photon) THEN 
+        current => species%attached_list%head 
+        DO WHILE (ASSOCIATED(current))
+          current%particle_energy = SQRT(SUM(current%part_p**2)) * c
+          current => current%next
+        END DO
+      END IF
+#endif
     END DO
 
     IF (pre_loading) RETURN

--- a/epoch3d/src/user_interaction/helper.F90
+++ b/epoch3d/src/user_interaction/helper.F90
@@ -102,9 +102,11 @@ CONTAINS
 
     INTEGER :: ispecies, n
     TYPE(particle_species), POINTER :: species
-    TYPE(particle), POINTER :: current
     INTEGER :: i0, i1, iu, io
     TYPE(initial_condition_block), POINTER :: ic
+#if defined(PHOTONS) || defined(BREMSSTRAHLUNG)
+    TYPE(particle), POINTER :: current
+#endif
 
     IF (pre_loading .AND. n_species > 0) THEN
       i0 = 1 - ng


### PR DESCRIPTION
In issue #502, we see that photons vanish from the simulation window when they are either injected using plasma injectors, or initialised using the `auto_load` subroutine. This issue has been traced back to the `push_photons` subroutine in `particles.F90`. Unlike the `push_particles` routine, `push_photons` uses the additional particle variable `particle_energy`, which is only defined when the code is compiled with `-DPHOTONS` or `-DBREMSSTRAHLUNG`. This variable is set upon creation of a photon using the physics packages, but _not_ when photons are either injected or initialised. In these cases `particle_energy=0`, which leads to infinite particle displacement, which immediately pushes photons outside the simulation window.

In this fix, we properly set the `particle_energy` variable for both injectors, and in the `auto_load` subroutine.