### PR TITLE
Bugfix for file-injectors

### DIFF
--- a/epoch1d/src/housekeeping/utilities.f90
+++ b/epoch1d/src/housekeeping/utilities.f90
@@ -343,7 +343,7 @@ CONTAINS
   SUBROUTINE setup_grid_x
 
     INTEGER :: iproc
-    REAL(num) :: boundary_shift
+    REAL(num) :: boundary_shift, hdx
 
     ! Setup local grid
     x(1-ng:nx+ng) = x_global(nx_global_min-ng:nx_global_max+ng)
@@ -357,8 +357,12 @@ CONTAINS
     x_grid_min_local = x_grid_mins(x_coords)
     x_grid_max_local = x_grid_maxs(x_coords)
 
-    x_min_local = x_grid_min_local + (cpml_x_min_offset - 0.5_num) * dx
-    x_max_local = x_grid_max_local - (cpml_x_max_offset - 0.5_num) * dx
+    hdx = 0.5_num * dx
+    x_min_local = x_grid_min_local - hdx
+    x_max_local = x_global(cell_x_max(x_coords+1)+1) - hdx
+
+    x_min_local = x_min_local + cpml_x_min_offset * dx
+    x_max_local = x_max_local - cpml_x_max_offset * dx
 
     boundary_shift = REAL((1 + png + cpml_thickness) / 2, num)
     x_min_outer = x_min - boundary_shift * dx

--- a/epoch2d/src/housekeeping/utilities.f90
+++ b/epoch2d/src/housekeeping/utilities.f90
@@ -343,7 +343,7 @@ CONTAINS
   SUBROUTINE setup_grid_x
 
     INTEGER :: iproc
-    REAL(num) :: boundary_shift
+    REAL(num) :: boundary_shift, hdx
 
     ! Setup local grid
     x(1-ng:nx+ng) = x_global(nx_global_min-ng:nx_global_max+ng)
@@ -357,8 +357,12 @@ CONTAINS
     x_grid_min_local = x_grid_mins(x_coords)
     x_grid_max_local = x_grid_maxs(x_coords)
 
-    x_min_local = x_grid_min_local + (cpml_x_min_offset - 0.5_num) * dx
-    x_max_local = x_grid_max_local - (cpml_x_max_offset - 0.5_num) * dx
+    hdx = 0.5_num * dx
+    x_min_local = x_grid_min_local - hdx
+    x_max_local = x_global(cell_x_max(x_coords+1)+1) - hdx
+
+    x_min_local = x_min_local + cpml_x_min_offset * dx
+    x_max_local = x_max_local - cpml_x_max_offset * dx
 
     boundary_shift = REAL((1 + png + cpml_thickness) / 2, num)
     x_min_outer = x_min - boundary_shift * dx
@@ -379,7 +383,7 @@ CONTAINS
   SUBROUTINE setup_grid_y
 
     INTEGER :: iproc
-    REAL(num) :: boundary_shift
+    REAL(num) :: boundary_shift, hdy
 
     ! Setup local grid
     y(1-ng:ny+ng) = y_global(ny_global_min-ng:ny_global_max+ng)
@@ -393,8 +397,12 @@ CONTAINS
     y_grid_min_local = y_grid_mins(y_coords)
     y_grid_max_local = y_grid_maxs(y_coords)
 
-    y_min_local = y_grid_min_local + (cpml_y_min_offset - 0.5_num) * dy
-    y_max_local = y_grid_max_local - (cpml_y_max_offset - 0.5_num) * dy
+    hdy = 0.5_num * dy
+    y_min_local = y_grid_min_local - hdy
+    y_max_local = y_global(cell_y_max(y_coords+1)+1) - hdy
+
+    y_min_local = y_min_local + cpml_y_min_offset * dy
+    y_max_local = y_max_local - cpml_y_max_offset * dy
 
     boundary_shift = REAL((1 + png + cpml_thickness) / 2, num)
     y_min_outer = y_min - boundary_shift * dy

--- a/epoch3d/src/housekeeping/utilities.f90
+++ b/epoch3d/src/housekeeping/utilities.f90
@@ -343,7 +343,7 @@ CONTAINS
   SUBROUTINE setup_grid_x
 
     INTEGER :: iproc
-    REAL(num) :: boundary_shift
+    REAL(num) :: boundary_shift, hdx
 
     ! Setup local grid
     x(1-ng:nx+ng) = x_global(nx_global_min-ng:nx_global_max+ng)
@@ -357,8 +357,12 @@ CONTAINS
     x_grid_min_local = x_grid_mins(x_coords)
     x_grid_max_local = x_grid_maxs(x_coords)
 
-    x_min_local = x_grid_min_local + (cpml_x_min_offset - 0.5_num) * dx
-    x_max_local = x_grid_max_local - (cpml_x_max_offset - 0.5_num) * dx
+    hdx = 0.5_num * dx
+    x_min_local = x_grid_min_local - hdx
+    x_max_local = x_global(cell_x_max(x_coords+1)+1) - hdx
+
+    x_min_local = x_min_local + cpml_x_min_offset * dx
+    x_max_local = x_max_local - cpml_x_max_offset * dx
 
     boundary_shift = REAL((1 + png + cpml_thickness) / 2, num)
     x_min_outer = x_min - boundary_shift * dx
@@ -379,7 +383,7 @@ CONTAINS
   SUBROUTINE setup_grid_y
 
     INTEGER :: iproc
-    REAL(num) :: boundary_shift
+    REAL(num) :: boundary_shift, hdy
 
     ! Setup local grid
     y(1-ng:ny+ng) = y_global(ny_global_min-ng:ny_global_max+ng)
@@ -393,8 +397,12 @@ CONTAINS
     y_grid_min_local = y_grid_mins(y_coords)
     y_grid_max_local = y_grid_maxs(y_coords)
 
-    y_min_local = y_grid_min_local + (cpml_y_min_offset - 0.5_num) * dy
-    y_max_local = y_grid_max_local - (cpml_y_max_offset - 0.5_num) * dy
+    hdy = 0.5_num * dy
+    y_min_local = y_grid_min_local - hdy
+    y_max_local = y_global(cell_y_max(y_coords+1)+1) - hdy
+
+    y_min_local = y_min_local + cpml_y_min_offset * dy
+    y_max_local = y_max_local - cpml_y_max_offset * dy
 
     boundary_shift = REAL((1 + png + cpml_thickness) / 2, num)
     y_min_outer = y_min - boundary_shift * dy
@@ -415,7 +423,7 @@ CONTAINS
   SUBROUTINE setup_grid_z
 
     INTEGER :: iproc
-    REAL(num) :: boundary_shift
+    REAL(num) :: boundary_shift, hdz
 
     ! Setup local grid
     z(1-ng:nz+ng) = z_global(nz_global_min-ng:nz_global_max+ng)
@@ -429,8 +437,12 @@ CONTAINS
     z_grid_min_local = z_grid_mins(z_coords)
     z_grid_max_local = z_grid_maxs(z_coords)
 
-    z_min_local = z_grid_min_local + (cpml_z_min_offset - 0.5_num) * dz
-    z_max_local = z_grid_max_local - (cpml_z_max_offset - 0.5_num) * dz
+    hdz = 0.5_num * dz
+    z_min_local = z_grid_min_local - hdz
+    z_max_local = z_global(cell_z_max(z_coords+1)+1) - hdz
+
+    z_min_local = z_min_local + cpml_z_min_offset * dz
+    z_max_local = z_max_local - cpml_z_max_offset * dz
 
     boundary_shift = REAL((1 + png + cpml_thickness) / 2, num)
     z_min_outer = z_min - boundary_shift * dz


### PR DESCRIPTION
This fixes issue #578 

The calculations for x_min_local, etc. are done in a consistent manner across all ranks. Note that there might still be inconsistencies when CPML boundaries are requested, but these should not be used in conjunction with injectors anyway.