### PR TITLE
Fix laser injection diagnostic for x/y/z max boundaries

### DIFF
--- a/epoch1d/src/laser.f90
+++ b/epoch1d/src/laser.f90
@@ -431,7 +431,8 @@ CONTAINS
           laser_inject_sum = 0.0_num
           laser_inject_sum = laser_inject_sum + current%profile**2
           t_env = laser_time_profile(current)
-          lfactor = 0.5_num * epsilon0 * c * factor * (t_env * current%amp)**2
+          lfactor = 0.5_num * epsilon0 * c * ABS(factor) &
+              * (t_env * current%amp)**2
           laser_inject_local = laser_inject_local + lfactor * laser_inject_sum
         END IF
         current => current%next

--- a/epoch2d/src/laser.f90
+++ b/epoch2d/src/laser.f90
@@ -685,7 +685,8 @@ CONTAINS
             laser_inject_sum = laser_inject_sum + current%profile(icell)**2
           END DO
           t_env = laser_time_profile(current)
-          lfactor = 0.5_num * epsilon0 * c * factor * (t_env * current%amp)**2
+          lfactor = 0.5_num * epsilon0 * c * ABS(factor) &
+              * (t_env * current%amp)**2
           laser_inject_local = laser_inject_local + lfactor * laser_inject_sum
         END IF
         current => current%next

--- a/epoch3d/src/laser.f90
+++ b/epoch3d/src/laser.f90
@@ -928,7 +928,8 @@ CONTAINS
           END DO
           END DO
           t_env = laser_time_profile(current)
-          lfactor = 0.5_num * epsilon0 * c * factor * (t_env * current%amp)**2
+          lfactor = 0.5_num * epsilon0 * c * ABS(factor) &
+              * (t_env * current%amp)**2
           laser_inject_local = laser_inject_local + lfactor * laser_inject_sum
         END IF
         current => current%next


### PR DESCRIPTION
Fix issue where the energy injected from x/y/z maximum boundaries is negative, resulting in zero absorption coefficients.

Fixes #893 