### PR TITLE
Add parsing of temp(species) to maths parser

### DIFF
--- a/epoch1d/src/constants.F90
+++ b/epoch1d/src/constants.F90
@@ -543,6 +543,7 @@ MODULE constants
   INTEGER, PARAMETER :: c_func_arctan2 = 47
   INTEGER, PARAMETER :: c_func_min = 48
   INTEGER, PARAMETER :: c_func_max = 49
+  INTEGER, PARAMETER :: c_func_temp = 50
 
   INTEGER, PARAMETER :: c_func_custom_lowbound = 4096
 

--- a/epoch1d/src/parser/shunt.F90
+++ b/epoch1d/src/parser/shunt.F90
@@ -714,6 +714,10 @@ CONTAINS
 
     IF (opcode == c_func_rho) THEN
       CALL copy_stack(species_list(id)%density_function, func_stack)
+    ELSE IF (opcode == c_func_temp) THEN
+      CALL copy_stack(species_list(id)%temperature_function(1), func_stack)
+      CALL copy_stack(species_list(id)%temperature_function(2), func_stack)
+      CALL copy_stack(species_list(id)%temperature_function(3), func_stack)
     ELSE IF (opcode == c_func_tempx) THEN
       CALL copy_stack(species_list(id)%temperature_function(1), func_stack)
     ELSE IF (opcode == c_func_tempy) THEN

--- a/epoch1d/src/parser/tokenizer_blocks.f90
+++ b/epoch1d/src/parser/tokenizer_blocks.f90
@@ -559,6 +559,12 @@ CONTAINS
         .OR. str_cmp(name, 'number_density')) THEN
       as_function = c_func_rho
 
+    ELSE IF (str_cmp(name, 'temp') &
+        .OR. str_cmp(name, 'temp_k') &
+        .OR. str_cmp(name, 'temperature') &
+        .OR. str_cmp(name, 'temperature_k')) THEN
+      as_function = c_func_temp
+
     ELSE IF (str_cmp(name, 'temp_x') &
         .OR. str_cmp(name, 'temp_x_k') &
         .OR. str_cmp(name, 'temperature_x') &

--- a/epoch2d/src/constants.F90
+++ b/epoch2d/src/constants.F90
@@ -545,6 +545,7 @@ MODULE constants
   INTEGER, PARAMETER :: c_func_arctan2 = 47
   INTEGER, PARAMETER :: c_func_min = 48
   INTEGER, PARAMETER :: c_func_max = 49
+  INTEGER, PARAMETER :: c_func_temp = 50
 
   INTEGER, PARAMETER :: c_func_custom_lowbound = 4096
 

--- a/epoch2d/src/parser/shunt.F90
+++ b/epoch2d/src/parser/shunt.F90
@@ -714,6 +714,10 @@ CONTAINS
 
     IF (opcode == c_func_rho) THEN
       CALL copy_stack(species_list(id)%density_function, func_stack)
+    ELSE IF (opcode == c_func_temp) THEN
+      CALL copy_stack(species_list(id)%temperature_function(1), func_stack)
+      CALL copy_stack(species_list(id)%temperature_function(2), func_stack)
+      CALL copy_stack(species_list(id)%temperature_function(3), func_stack)
     ELSE IF (opcode == c_func_tempx) THEN
       CALL copy_stack(species_list(id)%temperature_function(1), func_stack)
     ELSE IF (opcode == c_func_tempy) THEN

--- a/epoch2d/src/parser/tokenizer_blocks.f90
+++ b/epoch2d/src/parser/tokenizer_blocks.f90
@@ -559,6 +559,12 @@ CONTAINS
         .OR. str_cmp(name, 'number_density')) THEN
       as_function = c_func_rho
 
+    ELSE IF (str_cmp(name, 'temp') &
+        .OR. str_cmp(name, 'temp_k') &
+        .OR. str_cmp(name, 'temperature') &
+        .OR. str_cmp(name, 'temperature_k')) THEN
+      as_function = c_func_temp
+
     ELSE IF (str_cmp(name, 'temp_x') &
         .OR. str_cmp(name, 'temp_x_k') &
         .OR. str_cmp(name, 'temperature_x') &

--- a/epoch3d/src/constants.F90
+++ b/epoch3d/src/constants.F90
@@ -546,6 +546,7 @@ MODULE constants
   INTEGER, PARAMETER :: c_func_arctan2 = 47
   INTEGER, PARAMETER :: c_func_min = 48
   INTEGER, PARAMETER :: c_func_max = 49
+  INTEGER, PARAMETER :: c_func_temp = 50
 
   INTEGER, PARAMETER :: c_func_custom_lowbound = 4096
 

--- a/epoch3d/src/parser/shunt.F90
+++ b/epoch3d/src/parser/shunt.F90
@@ -714,6 +714,10 @@ CONTAINS
 
     IF (opcode == c_func_rho) THEN
       CALL copy_stack(species_list(id)%density_function, func_stack)
+    ELSE IF (opcode == c_func_temp) THEN
+      CALL copy_stack(species_list(id)%temperature_function(1), func_stack)
+      CALL copy_stack(species_list(id)%temperature_function(2), func_stack)
+      CALL copy_stack(species_list(id)%temperature_function(3), func_stack)
     ELSE IF (opcode == c_func_tempx) THEN
       CALL copy_stack(species_list(id)%temperature_function(1), func_stack)
     ELSE IF (opcode == c_func_tempy) THEN

--- a/epoch3d/src/parser/tokenizer_blocks.f90
+++ b/epoch3d/src/parser/tokenizer_blocks.f90
@@ -541,6 +541,12 @@ CONTAINS
         .OR. str_cmp(name, 'number_density')) THEN
       as_function = c_func_rho
 
+    ELSE IF (str_cmp(name, 'temp') &
+        .OR. str_cmp(name, 'temp_k') &
+        .OR. str_cmp(name, 'temperature') &
+        .OR. str_cmp(name, 'temperature_k')) THEN
+      as_function = c_func_temp
+
     ELSE IF (str_cmp(name, 'temp_x') &
         .OR. str_cmp(name, 'temp_x_k') &
         .OR. str_cmp(name, 'temperature_x') &


### PR DESCRIPTION
Add temp(species_name) to maths parser, as the documentation suggests should be an option. Fixes #899.